### PR TITLE
feature/GHA-0007: Check environments and state management

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
         uses: subhamay-bhattacharyya-gha/tf-validate-action@main
         with:
           terraform-dir: ${{ inputs.terraform-dir }}              
-          s3-bucket: ${{ vars.TERRAFORM_STATE_BUCKET }}
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
           s3-region: ${{ vars.AWS_REGION }}
           ci-pipeline: "true"
           soft-fail: "true"                                  

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,8 @@ jobs:
         uses: subhamay-bhattacharyya-gha/check-environments-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          org-short-name: "sb"
-          region: "us-east-1"
+          org-short-name: ${{ vars.ORG_SHORT_NAME }}
+          region: ${{ vars.AWS_REGION }}
 
   check-branch-issue:
     name: 🔎 Check Branch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -321,7 +321,7 @@ jobs:
         with:
           terraform-dir: ${{ inputs.terraform-dir }} 
           tf-vars-file: ${{ inputs.tf-vars-file }}
-          s3-bucket: ${{ vars.TERRAFORM_STATE_BUCKET }}
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
           s3-region: ${{ vars.AWS_REGION }}
           ci-pipeline: ${{ inputs.ci-pipeline }}
 
@@ -344,7 +344,7 @@ jobs:
         with:
           terraform-dir: ${{ inputs.terraform-dir }} 
           ci-pipeline: ${{ inputs.ci-pipeline }}
-          s3-bucket: ${{ vars.TERRAFORM_STATE_BUCKET }}
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
           s3-region: ${{ vars.AWS_REGION }}
           infracost-api-key: ${{ secrets.infracost-api-key }}
           gist-id: ${{ secrets.infracost-gist-id }}
@@ -368,7 +368,7 @@ jobs:
         id: apply
         with:
           terraform-dir: ${{ inputs.terraform-dir }}
-          s3-bucket: ${{ vars.TERRAFORM_STATE_BUCKET }}
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
           s3-region: ${{ vars.AWS_REGION }}
           ci-pipeline: ${{ inputs.ci-pipeline }}
 
@@ -387,18 +387,24 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Terraform Destroy
-        uses: subhamay-bhattacharyya-gha/tf-destroy-action@feature/GHA-0005-terraform-state-managemen
+        uses: subhamay-bhattacharyya-gha/tf-destroy-action@main
         id: destroy
         with:
           terraform-dir: ${{ inputs.terraform-dir }}
-          s3-bucket: ${{ vars.TERRAFORM_STATE_BUCKET }}
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
           s3-region: ${{ vars.AWS_REGION }}
           ci-pipeline: ${{ inputs.ci-pipeline }}
 
-  create-pull-request:
-    name: 🚀 Create Pull Request
+  create-release:
+    name: 🚀 Create Release
     runs-on: ubuntu-latest
-    if: always()
+    if: |
+        (needs.build-lambda.result == 'success' ||
+          needs.build-lambda-layer.result == 'success' ||
+          needs.build-glue.result == 'success' ||
+          needs.build-state-machine.result == 'success' ||
+          needs.terraform-destroy.result == 'success') &&
+          github.ref == 'refs/heads/main'
     needs: 
     - build-lambda
     - build-lambda-layer
@@ -412,6 +418,14 @@ jobs:
     - terraform-apply
     - terraform-destroy
     steps:
-      - name: Create Pull Request
-        id: create-pr
-        run: echo "CI Build completed. Proceed to create a pull request." >> $GITHUB_STEP_SUMMARY
+      - name: Create Release
+        uses: subhamay-bhattacharyya-gha/create-release-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag-name: ${{ github.ref_name }}
+          release-name: Release ${{ github.ref_name }}
+          release-body: |
+            This is an automated release created by the CI pipeline.
+            It includes the latest changes from the main branch.
+          draft: false
+          prerelease: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Check Available Environments
         id: check
-        uses: subhamay-bhattacharyya-gha/check-environments-action@ffc42d40f4676b08eeaac06878ad1ba4f98c502b
+        uses: subhamay-bhattacharyya-gha/check-environments-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           org-short-name: ${{ vars.ORG_SHORT_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Check Available Environments
         id: check
-        uses: subhamay-bhattacharyya-gha/check-environments-action@v1.1.0
+        uses: subhamay-bhattacharyya-gha/check-environments-action@ffc42d40f4676b08eeaac06878ad1ba4f98c502b
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           org-short-name: ${{ vars.ORG_SHORT_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Check Available Environments
         id: check
-        uses: subhamay-bhattacharyya-gha/check-environments-action@main
+        uses: subhamay-bhattacharyya-gha/check-environments-action@v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           org-short-name: ${{ vars.ORG_SHORT_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Check Available Environments
         id: check
-        uses: subhamay-bhattacharyya-gha/check-environments-action@feature/GHA-0008-rename-environments
+        uses: subhamay-bhattacharyya-gha/check-environments-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           org-short-name: "sb"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
   check-environments:
     name: 🔎 Check Env
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
       - name: Check Available Environments
         id: check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Verify branch issue
         id: branch-issue
-        uses: subhamay-bhattacharyya-gha/branch-issue-action@main
+        uses: subhamay-bhattacharyya-gha/branch-issue-action@feature/GHA-0008-rename-environments
 
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
         uses: subhamay-bhattacharyya-gha/check-environments-action@feature/GHA-0008-rename-environments
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          org-short-name: "sb"
+          region: "us-east-1"
 
   check-branch-issue:
     name: 🔎 Check Branch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Check Available Environments
         id: check
-        uses: subhamay-bhattacharyya-gha/check-environments-action@main
+        uses: subhamay-bhattacharyya-gha/check-environments-action@feature/GHA-0008-rename-environments
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Verify branch issue
         id: branch-issue
-        uses: subhamay-bhattacharyya-gha/branch-issue-action@feature/GHA-0008-rename-environments
+        uses: subhamay-bhattacharyya-gha/branch-issue-action@main
 
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the CI workflow configuration in `.github/workflows/ci.yaml` to improve environment handling, standardize variable usage, and transition from pull request creation to release creation. The most important changes include adding new environment inputs, replacing outdated variable names, and switching the workflow's focus from pull requests to releases.

### Improvements to environment handling:
* Added `environment`, `org-short-name`, and `region` inputs to the `check-environments` job to enhance flexibility and configurability.

### Variable standardization:
* Replaced `vars.TERRAFORM_STATE_BUCKET` with `vars.TF_STATE_BUCKET_NAME` across multiple jobs for consistent variable naming. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL192-R195) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL321-R324) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL344-R347) [[4]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL368-R371) [[5]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL387-R407)

### Transition to release creation:
* Renamed the `create-pull-request` job to `create-release` and updated its logic to trigger only under specific conditions.
* Replaced the pull request creation step with a release creation step using the `create-release-action`. This includes automated tagging, naming, and release notes generation.