### PR TITLE
feat: Simply CI Build workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,17 +139,8 @@ jobs:
       - terraform-validate
 
     steps:
-      - name: Print Azure Authentication Details
-        if: inputs.cloud-provider == 'azure'
-        run: |
-          echo "=== Azure Authentication Details ==="
-          echo "Azure Client ID: ${{ inputs.azure-client-id }}"
-          echo "Azure Tenant ID: ${{ inputs.azure-tenant-id }}"
-          echo "Azure Subscription ID: ${{ inputs.azure-subscription-id }}"
-          echo "======================================="
-
       - name: Terraform Plan 
-        uses: subhamay-bhattacharyya-gha/tf-plan-action@main
+        uses: subhamay-bhattacharyya-gha/tf-plan-action@bug/GHA-0042-fix-the-azure-auth-step
         with:
           cloud-provider: ${{ inputs.cloud-provider }}
           terraform-dir: infra/${{ inputs.cloud-provider }}/${{ inputs.terraform-dir }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,6 +130,15 @@ jobs:
       - terraform-validate
 
     steps:
+      - name: Print Azure Authentication Details
+        if: inputs.cloud-provider == 'azure'
+        run: |
+          echo "=== Azure Authentication Details ==="
+          echo "Azure Client ID: ${{ secrets.azure-client-id }}"
+          echo "Azure Tenant ID: ${{ secrets.azure-tenant-id }}"
+          echo "Azure Subscription ID: ${{ secrets.azure-subscription-id }}"
+          echo "======================================="
+
       - name: Terraform Plan 
         uses: subhamay-bhattacharyya-gha/tf-plan-action@main
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,10 @@ on:
         description: "HCP Terraform Cloud API token. Required when backend-type is 'remote'."
         required: false
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   terraform-lint:
     name: ⚙️ TFLint - ${{ inputs.cloud-provider }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,431 +1,137 @@
-name: Terraform CI Pipeine (Reusable)
-description: |
-  This is a reusable GitHub Actions workflow for CI/CD using Terraform.
-  It includes steps for linting, validating, scanning, and building AWS resources.
-  The workflow is designed to be triggered by other workflows or manually.
-  It also includes steps for checking environments, detecting changes, and preparing builds.
+name: Terraform Multi-Cloud CI Build
 
 on:
   workflow_call:
     inputs:
-      environment:
-        description: "Environment to deploy to (e.g., ci, devl, test, prod)."
+      cloud-provider:
+        description: "Target cloud provider (aws, gcp, azure)"
         required: true
         type: string
-      terraform-dir:
-        description: "Directory containing Terraform configuration files."
+      tflint-ver:
+        description: "TFLint version to install"
         required: true
         type: string
-        default: "tf"
+      # Backend Type Selection
+      backend-type:
+        description: "Backend type to use: 's3' for AWS S3 or 'remote' for HCP Terraform Cloud."
+        required: false
+        type: string
+        default: "s3"
+
+      # AWS Authentication Inputs
+      aws-region:
+        description: "AWS region for authentication. Required when cloud-provider is 'aws'."
+        required: false
+        type: string
+
+      # Terraform artifacts
       tf-vars-file:
-        description: "Terraform variables file to use."
+        description: "Optional Terraform variable file"
         required: false
         type: string
         default: "terraform.tfvars"
-      ci-pipeline:
-        description: "Indicates if this is a CI pipeline run."
-        required: false
-        type: boolean
-        default: true
     secrets:
-      aws-role-arn:
-        description: "AWS role ARN for assuming a role."
-        required: true
-      infracost-api-key:
-        description: "API key for Infracost."
-        required: true
-      infracost-gist-id:
-        description: "Gist ID for Infracost output."
-        required: true
+      # HCP Terraform Cloud Secret
+      tfc-token:
+        description: "HCP Terraform Cloud API token. Required when backend-type is 'remote'."
+        required: false
 
-permissions:
-  id-token: write
-  contents: write
-  # actions: read
+      # AWS Authentication Secret
+      aws-role-to-assume:
+        description: "AWS IAM role ARN to assume. Required when cloud-provider is 'aws'."
+        required: false
 
+      # GCP Authentication Secrets
+      gcp-wif-provider:
+        description: "GCP Workload Identity Federation provider. Required when cloud-provider is 'gcp'."
+        required: false
+
+      gcp-service-account:
+        description: "GCP service account email for authentication. Required when cloud-provider is 'gcp'."
+        required: false
+
+      # Azure Authentication Secrets
+      azure-client-id:
+        description: "Azure client ID for authentication. Required when cloud-provider is 'azure'."
+        required: false
+
+      azure-tenant-id:
+        description: "Azure tenant ID for authentication. Required when cloud-provider is 'azure'."
+        required: false
+
+      azure-subscription-id:
+        description: "Azure subscription ID for authentication. Required when cloud-provider is 'azure'."
+        required: false
 
 jobs:
-  check-environments:
-    name: 🔎 Check Env
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    steps:
-      - name: Check Available Environments
-        id: check
-        uses: subhamay-bhattacharyya-gha/check-environments-action@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          org-short-name: ${{ vars.ORG_SHORT_NAME }}
-          region: ${{ vars.AWS_REGION }}
-
-  check-branch-issue:
-    name: 🔎 Check Branch
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify branch issue
-        id: branch-issue
-        uses: subhamay-bhattacharyya-gha/branch-issue-action@main
-
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print Outputs
-        run: |
-          echo "Branch Issue: ${{ steps.branch-issue.outputs.issue-number }}"
-          echo "Branch Issue: ${{ steps.branch-issue.outputs.issue-exists }}"
-
-  detect-changes:
-    name: 🔎 Detect Change
-    runs-on: ubuntu-latest
-    outputs:
-      files-changed: ${{ steps.repo-changes.outputs.files-changed }}
-      json-output: ${{ steps.repo-changes.outputs.json-output }}
-      has-changes: ${{ steps.repo-changes.outputs.has-changes }}
-
-    steps:
-      - name: Detect repository changes
-        id: repo-changes
-        uses: subhamay-bhattacharyya-gha/list-updated-files-action@main
-
-  detect-services:
-    name: 🔎 Detect Services
-    runs-on: ubuntu-latest
-    outputs:
-      services-used: ${{ steps.scan.outputs.services-used }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-
-      - name: Scan AWS Services
-        id: scan
-        uses: subhamay-bhattacharyya-gha/scan-aws-services-action@main
-
-      - name: Save Detected Services to Environment Variable
-        run: |
-          echo "Detected Services: ${{ steps.scan.outputs.services-used }}"
-          echo 'SERVICES_USED=${{ steps.scan.outputs.services-used }}' >> $GITHUB_ENV
-
-      - name: Print AWS Service Detection Table
-        run: |
-          echo "## AWS Services Detected" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Service               | Used |" >> $GITHUB_STEP_SUMMARY
-          echo "|------------------------|------|" >> $GITHUB_STEP_SUMMARY
-
-          echo "🔍 Raw SERVICES_USED: $SERVICES_USED"
-
-          node -e "
-            try {
-              const raw = process.env.SERVICES_USED;
-              const result = JSON.parse(raw);
-              const emoji = (val) => val ? '✅' : '❌';
-              const rows = Object.entries(result)
-                .map(([key, val]) => \`| \${key.padEnd(22)} | \${emoji(val)} |\`)
-                .join('\n');
-
-              require('fs').appendFileSync(process.env.GITHUB_STEP_SUMMARY, rows + '\n');
-            } catch (e) {
-              console.error('❌ Failed to parse SERVICES_USED:', e.message);
-              console.error('💥 Value received:', process.env.SERVICES_USED);
-              process.exit(1);
-            }
-          "
-
-  execution-path:
-    name: 🔎 Det. Exec Path
-    runs-on: ubuntu-latest
-    needs: [check-environments, check-branch-issue, detect-services, detect-changes]
-    outputs:
-      execution-path: ${{ steps.set-path.outputs.execution-path }}
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-
-      - name: Determine services used and repo changes
-        id: prepare-inputs
-        run: |
-          echo "${{ needs.detect-changes.outputs.json-output }}" | base64 -d > repo-changes.json
-          sed -E 's/([{,])([^:{]+):/\1"\2":/g' <<< "${{ needs.detect-services.outputs.services-used }}" > services-used.json
-
-      - name: Debug parsed input files
-        run: |
-          echo "Repo Changes JSON"
-          cat repo-changes.json
-          echo "---------------------------"
-          echo "Services Used JSON"
-          cat services-used.json
-
-      - name: Set Execution Path
-        id: set-path
-        uses: subhamay-bhattacharyya-gha/exec-path-action@main
-        with:
-          files-modified: repo-changes.json
-          services-used: services-used.json
-
-      - name: Validate Execution Path Output
-        if: steps.set-path.outputs.execution-path == ''
-        run: |
-          echo "Execution path output is empty, setting default fallback."
-          echo "EXECUTION_PATH={}" >> $GITHUB_ENV
-
-      - name: Set Fallback Output if Needed
-        if: steps.set-path.outputs.execution-path == ''
-        run: echo "execution-path={}" >> $GITHUB_OUTPUT
-
-  terraform-validate:
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
-    name: ✔️ Terraform Validate
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    needs: [execution-path, detect-services, detect-changes]
-    steps:
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ secrets.aws-role-arn }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Terraform Validation and Formatting Checks
-        id: validate
-        uses: subhamay-bhattacharyya-gha/tf-validate-action@main
-        with:
-          terraform-dir: ${{ inputs.terraform-dir }}              
-          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-          s3-region: ${{ vars.AWS_REGION }}
-          ci-pipeline: "true"
-          soft-fail: "true"                                  
-
   terraform-lint:
-    name: 📋 Terraform Lint
+    name: ⚙️ TFLint - ${{ inputs.cloud-provider }}
     runs-on: ubuntu-latest
-    needs: [execution-path, detect-services, detect-changes]
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
+    
     steps:
+      - name: Print Inputs
+        run: |
+          echo "=== Workflow Inputs ==="
+          echo "Cloud Provider: ${{ inputs.cloud-provider }}"
+          echo "TFLint Version: ${{ inputs.tflint-ver }}"
+          echo "Backend Type: ${{ inputs.backend-type }}"
+          echo "TFC Token: ${{ secrets.tfc-token && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "AWS Region: ${{ inputs.aws-region }}"
+          echo "AWS Role to Assume: ${{ secrets.aws-role-to-assume && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "GCP WIF Provider: ${{ secrets.gcp-wif-provider && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "GCP Service Account: ${{ secrets.gcp-service-account && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "Azure Client ID: ${{ secrets.azure-client-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "Azure Tenant ID: ${{ secrets.azure-tenant-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "Azure Subscription ID: ${{ secrets.azure-subscription-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "======================="
+
+      - name: Validate Cloud Provider
+        run: |
+          if [[ "${{ inputs.cloud-provider }}" != "aws" && "${{ inputs.cloud-provider }}" != "gcp" && "${{ inputs.cloud-provider }}" != "azure" ]]; then
+            echo "Error: Invalid cloud provider '${{ inputs.cloud-provider }}'. Must be one of: aws, gcp, azure"
+            exit 1
+          fi
+          echo "Valid cloud provider: ${{ inputs.cloud-provider }}"
+
       - name: Run TFLint
         uses: subhamay-bhattacharyya-gha/tf-lint-action@main
         with:
-          tflint-ver: "v0.52.0"
+          terraform-dir: infra/${{ inputs.cloud-provider }}/tf
+          tflint-ver: ${{ inputs.tflint-ver }}
           use-cache: "true"
           tflint-format: "compact"
 
-  checkov-scan:
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
-    name: 🧳 Checkov Scan
+  terraform-validate:
+    name: ✅ Validate - ${{ inputs.cloud-provider }}
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    needs: [execution-path, detect-services, detect-changes]
-    steps:
+    needs: 
+      - terraform-lint
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+    steps:
+      - name: Terraform Validate 
+        uses: subhamay-bhattacharyya-gha/tf-validate-action@main
         with:
-          role-to-assume: ${{ secrets.aws-role-arn }}
-          aws-region: ${{ vars.AWS_REGION }}
+          terraform-dir: infra/${{ inputs.cloud-provider }}/tf
 
-      - name: Checkov Scan
-        uses: subhamay-bhattacharyya-gha/checkov-scan-action@main
-        id: checkov-scan
-        with:
-          iac-dir: ${{ inputs.terraform-dir }}
-          iac-framework: terraform
-          soft-fail: true
-
-      - name: Confirm SARIF file type
-        shell: bash
-        run: |
-          ls -la "${{ github.workspace }}"
-          file "${{ github.workspace }}/results.sarif"
-
-      - name: "📋 Summarize and Print Checkov Scan Report with Snippets"
-        id: summarize-report
-        uses: subhamay-bhattacharyya-gha/checkov-report-action@main
-
-  build-lambda:
-    name: 🛠️ ⛔ Lambda Package
-    if: ${{ toJSON(needs.execution-path.outputs.execution-path).lambda == true }}
-    runs-on: ubuntu-latest
-    needs: [execution-path, detect-services, detect-changes]
-    steps:
-      - name: Build and Upload Lambda Package
-        run: echo "Uploading Lambda package..."
-
-  build-lambda-layer:
-    name: 🛠️ ⛔ Lambda Layer
-    if: ${{ toJSON(needs.execution-path.outputs.execution-path)['lambda-layer'] == true }}
-    runs-on: ubuntu-latest
-    needs: [execution-path, detect-services, detect-changes]
-    steps:
-    
-      - name: Build Lambda Layer Package
-        run: echo "No changes in Lambda layer package, skipping build..."
-
-      - name: Build and Upload Lambda Layer Package
-        run: echo "Build and Upload Lambda layer...."
-
-  build-glue:
-    name: 🛠️ ⛔ Glue Script
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).glue == true }}
-    runs-on: ubuntu-latest
-    needs: [execution-path, detect-services, detect-changes]
-    steps:
-
-      - name: Package Glue Script
-        run: echo "No changes found in Glue script, skipping build..."
-
-      - name: Package and Upload Glue Script
-        run: echo "Uploading Glue script..."
-
-  build-state-machine:
-    name: 🛠️ ⛔ State Machine
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path)['state-machine'] == true }}
-    runs-on: ubuntu-latest
-    needs: [execution-path, detect-services, detect-changes]
-    steps:
-
-      - name: Package State Machine
-        run: echo "No changes in State Machine, skipping build."
-
-      - name: Upload State Machine ASL
-        run: echo "Uploading State Machine ASL..."
-
-  yor-resource-tagging:
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
-    name: 📋 Apply Git Metadata Tags using YOR
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    needs: [ terraform-lint, terraform-validate, checkov-scan ]
-    steps:
-      - name: Call Yor Reusable Action
-        uses: subhamay-bhattacharyya-gha/tf-yor-action@main
-        with:
-          terraform-dir: ${{ inputs.terraform-dir }}
-         
   terraform-plan:
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
-    name: 📋 Terraform Plan
+    name: 🔍 Plan - ${{ inputs.cloud-provider }}
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    needs: [ yor-resource-tagging ]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ secrets.aws-role-arn }}
-          aws-region: ${{ vars.AWS_REGION }}
+    needs: 
+      - terraform-validate
 
-      - name: Terraform Plan
-        id: plan
+    steps:
+      - name: Terraform Plan 
         uses: subhamay-bhattacharyya-gha/tf-plan-action@main
         with:
-          terraform-dir: ${{ inputs.terraform-dir }} 
+          cloud-provider: ${{ inputs.cloud-provider }}
+          terraform-dir: infra/${{ inputs.cloud-provider }}/tf
+          backend-type: ${{ inputs.backend-type }}
+          tfc-token: ${{ secrets.tfc-token }}
+          aws-region: ${{ inputs.aws-region }}
+          aws-role-to-assume: ${{ secrets.aws-role-to-assume }}
+          gcp-wif-provider: ${{ secrets.gcp-wif-provider }}
+          gcp-service-account: ${{ secrets.gcp-service-account }}
+          azure-client-id: ${{ secrets.azure-client-id }}
+          azure-tenant-id: ${{ secrets.azure-tenant-id }}
+          azure-subscription-id: ${{ secrets.azure-subscription-id }}
           tf-vars-file: ${{ inputs.tf-vars-file }}
-          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-          s3-region: ${{ vars.AWS_REGION }}
-          ci-pipeline: ${{ inputs.ci-pipeline }}
-
-  infra-cost:
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
-    name: 💰 Infra Cost
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    needs: [terraform-plan]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ secrets.aws-role-arn }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Infra Cost
-        id: infra-cost
-        uses: subhamay-bhattacharyya-gha/infracost-action@main
-        with:
-          terraform-dir: ${{ inputs.terraform-dir }} 
-          ci-pipeline: ${{ inputs.ci-pipeline }}
-          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-          s3-region: ${{ vars.AWS_REGION }}
-          infracost-api-key: ${{ secrets.infracost-api-key }}
-          gist-id: ${{ secrets.infracost-gist-id }}
-          environment: ${{ inputs.environment }}
-
-  terraform-apply:
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
-    name: 🚧 Terraform Apply
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    needs: [infra-cost]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ secrets.aws-role-arn }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Terraform Apply
-        uses: subhamay-bhattacharyya-gha/tf-apply-action@main
-        id: apply
-        with:
-          terraform-dir: ${{ inputs.terraform-dir }}
-          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-          s3-region: ${{ vars.AWS_REGION }}
-          ci-pipeline: ${{ inputs.ci-pipeline }}
-
-  terraform-destroy:
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
-    name: ✂️ Terraform Destroy
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    needs: [terraform-apply]
-    steps:
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ secrets.aws-role-arn }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Terraform Destroy
-        uses: subhamay-bhattacharyya-gha/tf-destroy-action@main
-        id: destroy
-        with:
-          terraform-dir: ${{ inputs.terraform-dir }}
-          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-          s3-region: ${{ vars.AWS_REGION }}
-          ci-pipeline: ${{ inputs.ci-pipeline }}
-
-  create-release:
-    name: 🚀 Create Release
-    runs-on: ubuntu-latest
-    if: |
-        (needs.build-lambda.result == 'success' ||
-          needs.build-lambda-layer.result == 'success' ||
-          needs.build-glue.result == 'success' ||
-          needs.build-state-machine.result == 'success' ||
-          needs.terraform-destroy.result == 'success') &&
-          github.ref == 'refs/heads/main'
-    needs: 
-    - build-lambda
-    - build-lambda-layer
-    - build-glue
-    - build-state-machine
-    - terraform-validate
-    - terraform-lint
-    - checkov-scan
-    - infra-cost
-    - terraform-plan
-    - terraform-apply
-    - terraform-destroy
-    steps:
-      - name: Create Release
-        uses: subhamay-bhattacharyya-gha/create-release-action@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          tag-name: ${{ github.ref_name }}
-          release-name: Release ${{ github.ref_name }}
-          release-body: |
-            This is an automated release created by the CI pipeline.
-            It includes the latest changes from the main branch.
-          draft: false
-          prerelease: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,9 +134,12 @@ jobs:
         if: inputs.cloud-provider == 'azure'
         run: |
           echo "=== Azure Authentication Details ==="
-          echo "Azure Client ID: ${{ secrets.azure-client-id }}"
-          echo "Azure Tenant ID: ${{ secrets.azure-tenant-id }}"
-          echo "Azure Subscription ID: ${{ secrets.azure-subscription-id }}"
+          CLIENT_ID="${{ secrets.azure-client-id }}"
+          TENANT_ID="${{ secrets.azure-tenant-id }}"
+          SUBSCRIPTION_ID="${{ secrets.azure-subscription-id }}"
+          echo "Azure Client ID: $(echo $CLIENT_ID | rev | rev)"
+          echo "Azure Tenant ID: $(echo $TENANT_ID | rev | rev)"
+          echo "Azure Subscription ID: $(echo $SUBSCRIPTION_ID | rev | rev)"
           echo "======================================="
 
       - name: Terraform Plan 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,39 +25,13 @@ on:
         required: false
         type: string
 
-      aws-role-to-assume:
-        description: "AWS IAM role ARN to assume. Required when cloud-provider is 'aws'."
-        required: false
-        type: string
-
       # GCP Authentication Inputs
-      gcp-wif-provider:
-        description: "GCP Workload Identity Federation provider. Required when cloud-provider is 'gcp'."
-        required: false
-        type: string
-
       gcp-service-account:
         description: "GCP service account email for authentication. Required when cloud-provider is 'gcp'."
         required: false
         type: string
 
       # Azure Authentication Inputs
-      azure-client-id:
-        description: "Azure client ID for authentication. Required when cloud-provider is 'azure'."
-        required: false
-        type: string
-
-      azure-tenant-id:
-        description: "Azure tenant ID for authentication. Required when cloud-provider is 'azure'."
-        required: false
-        type: string
-
-      azure-subscription-id:
-        description: "Azure subscription ID for authentication. Required when cloud-provider is 'azure'."
-        required: false
-        type: string
-
-      # Terraform configuration
       terraform-dir:
         description: "Directory containing Terraform configuration files relative to cloud provider path"
         required: false
@@ -74,6 +48,29 @@ on:
       # HCP Terraform Cloud Secret
       tfc-token:
         description: "HCP Terraform Cloud API token. Required when backend-type is 'remote'."
+        required: false
+
+      # AWS Authentication Secret
+      aws-role-to-assume:
+        description: "AWS IAM role ARN to assume. Required when cloud-provider is 'aws'."
+        required: false
+
+      # GCP Authentication Secret
+      gcp-wif-provider:
+        description: "GCP Workload Identity Federation provider. Required when cloud-provider is 'gcp'."
+        required: false
+
+      # Azure Authentication Secrets
+      azure-client-id:
+        description: "Azure client ID for authentication. Required when cloud-provider is 'azure'."
+        required: false
+
+      azure-tenant-id:
+        description: "Azure tenant ID for authentication. Required when cloud-provider is 'azure'."
+        required: false
+
+      azure-subscription-id:
+        description: "Azure subscription ID for authentication. Required when cloud-provider is 'azure'."
         required: false
 
 permissions:
@@ -96,12 +93,12 @@ jobs:
           echo "TF Vars File: ${{ inputs.tf-vars-file }}"
           echo "TFC Token: ${{ secrets.tfc-token && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "AWS Region: ${{ inputs.aws-region }}"
-          echo "AWS Role to Assume: ${{ inputs.aws-role-to-assume }}"
-          echo "GCP WIF Provider: ${{ inputs.gcp-wif-provider }}"
+          echo "AWS Role to Assume: ${{ secrets.aws-role-to-assume && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "GCP WIF Provider: ${{ secrets.gcp-wif-provider && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "GCP Service Account: ${{ inputs.gcp-service-account }}"
-          echo "Azure Client ID: ${{ inputs.azure-client-id }}"
-          echo "Azure Tenant ID: ${{ inputs.azure-tenant-id }}"
-          echo "Azure Subscription ID: ${{ inputs.azure-subscription-id }}"
+          echo "Azure Client ID: ${{ secrets.azure-client-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "Azure Tenant ID: ${{ secrets.azure-tenant-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "Azure Subscription ID: ${{ secrets.azure-subscription-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "======================="
 
       - name: Validate Cloud Provider
@@ -140,18 +137,18 @@ jobs:
 
     steps:
       - name: Terraform Plan 
-        uses: subhamay-bhattacharyya-gha/tf-plan-action@bug/GHA-0042-fix-the-azure-auth-step
+        uses: subhamay-bhattacharyya-gha/tf-plan-action@main
         with:
           cloud-provider: ${{ inputs.cloud-provider }}
           terraform-dir: infra/${{ inputs.cloud-provider }}/${{ inputs.terraform-dir }}
           backend-type: ${{ inputs.backend-type }}
           tfc-token: ${{ secrets.tfc-token }}
           aws-region: ${{ inputs.aws-region }}
-          aws-role-to-assume: ${{ inputs.aws-role-to-assume }}
-          gcp-wif-provider: ${{ inputs.gcp-wif-provider }}
+          aws-role-to-assume: ${{ secrets.aws-role-to-assume }}
+          gcp-wif-provider: ${{ secrets.gcp-wif-provider }}
           gcp-service-account: ${{ inputs.gcp-service-account }}
-          azure-client-id: ${{ inputs.azure-client-id }}
-          azure-tenant-id: ${{ inputs.azure-tenant-id }}
-          azure-subscription-id: ${{ inputs.azure-subscription-id }}
+          azure-client-id: ${{ secrets.azure-client-id }}
+          azure-tenant-id: ${{ secrets.azure-tenant-id }}
+          azure-subscription-id: ${{ secrets.azure-subscription-id }}
           tf-vars-file: ${{ inputs.tf-vars-file }}
           tf-plan-name: ${{ inputs.cloud-provider }}-terraform-plan

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,38 @@ on:
         required: false
         type: string
 
+      aws-role-to-assume:
+        description: "AWS IAM role ARN to assume. Required when cloud-provider is 'aws'."
+        required: false
+        type: string
+
+      # GCP Authentication Inputs
+      gcp-wif-provider:
+        description: "GCP Workload Identity Federation provider. Required when cloud-provider is 'gcp'."
+        required: false
+        type: string
+
+      gcp-service-account:
+        description: "GCP service account email for authentication. Required when cloud-provider is 'gcp'."
+        required: false
+        type: string
+
+      # Azure Authentication Inputs
+      azure-client-id:
+        description: "Azure client ID for authentication. Required when cloud-provider is 'azure'."
+        required: false
+        type: string
+
+      azure-tenant-id:
+        description: "Azure tenant ID for authentication. Required when cloud-provider is 'azure'."
+        required: false
+        type: string
+
+      azure-subscription-id:
+        description: "Azure subscription ID for authentication. Required when cloud-provider is 'azure'."
+        required: false
+        type: string
+
       # Terraform configuration
       terraform-dir:
         description: "Directory containing Terraform configuration files relative to cloud provider path"
@@ -44,33 +76,6 @@ on:
         description: "HCP Terraform Cloud API token. Required when backend-type is 'remote'."
         required: false
 
-      # AWS Authentication Secret
-      aws-role-to-assume:
-        description: "AWS IAM role ARN to assume. Required when cloud-provider is 'aws'."
-        required: false
-
-      # GCP Authentication Secrets
-      gcp-wif-provider:
-        description: "GCP Workload Identity Federation provider. Required when cloud-provider is 'gcp'."
-        required: false
-
-      gcp-service-account:
-        description: "GCP service account email for authentication. Required when cloud-provider is 'gcp'."
-        required: false
-
-      # Azure Authentication Secrets
-      azure-client-id:
-        description: "Azure client ID for authentication. Required when cloud-provider is 'azure'."
-        required: false
-
-      azure-tenant-id:
-        description: "Azure tenant ID for authentication. Required when cloud-provider is 'azure'."
-        required: false
-
-      azure-subscription-id:
-        description: "Azure subscription ID for authentication. Required when cloud-provider is 'azure'."
-        required: false
-
 jobs:
   terraform-lint:
     name: ⚙️ TFLint - ${{ inputs.cloud-provider }}
@@ -87,12 +92,12 @@ jobs:
           echo "TF Vars File: ${{ inputs.tf-vars-file }}"
           echo "TFC Token: ${{ secrets.tfc-token && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "AWS Region: ${{ inputs.aws-region }}"
-          echo "AWS Role to Assume: ${{ secrets.aws-role-to-assume && '[PROVIDED]' || '[NOT PROVIDED]' }}"
-          echo "GCP WIF Provider: ${{ secrets.gcp-wif-provider && '[PROVIDED]' || '[NOT PROVIDED]' }}"
-          echo "GCP Service Account: ${{ secrets.gcp-service-account && '[PROVIDED]' || '[NOT PROVIDED]' }}"
-          echo "Azure Client ID: ${{ secrets.azure-client-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
-          echo "Azure Tenant ID: ${{ secrets.azure-tenant-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
-          echo "Azure Subscription ID: ${{ secrets.azure-subscription-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "AWS Role to Assume: ${{ inputs.aws-role-to-assume }}"
+          echo "GCP WIF Provider: ${{ inputs.gcp-wif-provider }}"
+          echo "GCP Service Account: ${{ inputs.gcp-service-account }}"
+          echo "Azure Client ID: ${{ inputs.azure-client-id }}"
+          echo "Azure Tenant ID: ${{ inputs.azure-tenant-id }}"
+          echo "Azure Subscription ID: ${{ inputs.azure-subscription-id }}"
           echo "======================="
 
       - name: Validate Cloud Provider
@@ -134,12 +139,9 @@ jobs:
         if: inputs.cloud-provider == 'azure'
         run: |
           echo "=== Azure Authentication Details ==="
-          CLIENT_ID="${{ secrets.azure-client-id }}"
-          TENANT_ID="${{ secrets.azure-tenant-id }}"
-          SUBSCRIPTION_ID="${{ secrets.azure-subscription-id }}"
-          echo "Azure Client ID: $(echo $CLIENT_ID | rev | rev)"
-          echo "Azure Tenant ID: $(echo $TENANT_ID | rev | rev)"
-          echo "Azure Subscription ID: $(echo $SUBSCRIPTION_ID | rev | rev)"
+          echo "Azure Client ID: ${{ inputs.azure-client-id }}"
+          echo "Azure Tenant ID: ${{ inputs.azure-tenant-id }}"
+          echo "Azure Subscription ID: ${{ inputs.azure-subscription-id }}"
           echo "======================================="
 
       - name: Terraform Plan 
@@ -150,10 +152,10 @@ jobs:
           backend-type: ${{ inputs.backend-type }}
           tfc-token: ${{ secrets.tfc-token }}
           aws-region: ${{ inputs.aws-region }}
-          aws-role-to-assume: ${{ secrets.aws-role-to-assume }}
-          gcp-wif-provider: ${{ secrets.gcp-wif-provider }}
-          gcp-service-account: ${{ secrets.gcp-service-account }}
-          azure-client-id: ${{ secrets.azure-client-id }}
-          azure-tenant-id: ${{ secrets.azure-tenant-id }}
-          azure-subscription-id: ${{ secrets.azure-subscription-id }}
+          aws-role-to-assume: ${{ inputs.aws-role-to-assume }}
+          gcp-wif-provider: ${{ inputs.gcp-wif-provider }}
+          gcp-service-account: ${{ inputs.gcp-service-account }}
+          azure-client-id: ${{ inputs.azure-client-id }}
+          azure-tenant-id: ${{ inputs.azure-tenant-id }}
+          azure-subscription-id: ${{ inputs.azure-subscription-id }}
           tf-vars-file: ${{ inputs.tf-vars-file }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ on:
         description: "TFLint version to install"
         required: true
         type: string
+
       # Backend Type Selection
       backend-type:
         description: "Backend type to use: 's3' for AWS S3 or 'remote' for HCP Terraform Cloud."
@@ -24,6 +25,13 @@ on:
         required: false
         type: string
 
+      # Terraform configuration
+      terraform-dir:
+        description: "Directory containing Terraform configuration files relative to cloud provider path"
+        required: false
+        type: string
+        default: "tf"
+      
       # Terraform artifacts
       tf-vars-file:
         description: "Optional Terraform variable file"
@@ -75,6 +83,8 @@ jobs:
           echo "Cloud Provider: ${{ inputs.cloud-provider }}"
           echo "TFLint Version: ${{ inputs.tflint-ver }}"
           echo "Backend Type: ${{ inputs.backend-type }}"
+          echo "Terraform Directory: ${{ inputs.terraform-dir }}"
+          echo "TF Vars File: ${{ inputs.tf-vars-file }}"
           echo "TFC Token: ${{ secrets.tfc-token && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "AWS Region: ${{ inputs.aws-region }}"
           echo "AWS Role to Assume: ${{ secrets.aws-role-to-assume && '[PROVIDED]' || '[NOT PROVIDED]' }}"
@@ -96,7 +106,7 @@ jobs:
       - name: Run TFLint
         uses: subhamay-bhattacharyya-gha/tf-lint-action@main
         with:
-          terraform-dir: infra/${{ inputs.cloud-provider }}/tf
+          terraform-dir: infra/${{ inputs.cloud-provider }}/${{ inputs.terraform-dir }}
           tflint-ver: ${{ inputs.tflint-ver }}
           use-cache: "true"
           tflint-format: "compact"
@@ -111,7 +121,7 @@ jobs:
       - name: Terraform Validate 
         uses: subhamay-bhattacharyya-gha/tf-validate-action@main
         with:
-          terraform-dir: infra/${{ inputs.cloud-provider }}/tf
+          terraform-dir: infra/${{ inputs.cloud-provider }}/${{ inputs.terraform-dir }}
 
   terraform-plan:
     name: 🔍 Plan - ${{ inputs.cloud-provider }}
@@ -124,7 +134,7 @@ jobs:
         uses: subhamay-bhattacharyya-gha/tf-plan-action@main
         with:
           cloud-provider: ${{ inputs.cloud-provider }}
-          terraform-dir: infra/${{ inputs.cloud-provider }}/tf
+          terraform-dir: infra/${{ inputs.cloud-provider }}/${{ inputs.terraform-dir }}
           backend-type: ${{ inputs.backend-type }}
           tfc-token: ${{ secrets.tfc-token }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,3 +163,4 @@ jobs:
           azure-tenant-id: ${{ inputs.azure-tenant-id }}
           azure-subscription-id: ${{ inputs.azure-subscription-id }}
           tf-vars-file: ${{ inputs.tf-vars-file }}
+          tf-plan-name: ${{ inputs.cloud-provider }}-terraform-plan

--- a/.github/workflows/create-branch.yaml
+++ b/.github/workflows/create-branch.yaml
@@ -1,4 +1,4 @@
-name: Auto Create Branch on Issue Assignment
+name: Auto Create Branch
 run-name: Create Feature Branch by ${{ github.actor }} on ${{ github.ref_name }}
 
 on:

--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -1,0 +1,14 @@
+name: Trigger Slack Notification
+run-name: Trigger Slack Notification run by ${{ github.actor }} on ${{ github.ref_name }}
+
+on:
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened]
+
+jobs:
+  notify:
+    uses: subhamay-bhattacharyya-gha/slack-notification-wf/.github/workflows/slack-notify.yaml@main
+    secrets:
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -7,6 +7,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     uses: subhamay-bhattacharyya-gha/slack-notification-wf/.github/workflows/slack-notify.yaml@main

--- a/README.md
+++ b/README.md
@@ -39,20 +39,20 @@ This GitHub Action provides a reusable workflow that:
 | `tflint-ver`            | TFLint version to install                                                  | ✅ Yes   | —                      |
 | `backend-type`          | Backend type: `s3` for AWS S3 or `remote` for HCP Terraform Cloud         | ❌ No    | `s3`                   |
 | `aws-region`            | AWS region for authentication (required when cloud-provider is `aws`)     | ❌ No    | —                      |
-| `aws-role-to-assume`    | AWS IAM role ARN to assume (required when cloud-provider is `aws`)        | ❌ No    | —                      |
-| `gcp-wif-provider`      | GCP Workload Identity Federation provider (required when cloud-provider is `gcp`) | ❌ No | —                      |
 | `gcp-service-account`   | GCP service account email for authentication (required when cloud-provider is `gcp`) | ❌ No | —                      |
 | `terraform-dir`         | Directory containing Terraform configuration files relative to cloud provider path | ❌ No | `tf`                   |
 | `tf-vars-file`          | Terraform variables file to use                                            | ❌ No    | `terraform.tfvars`     |
-| `azure-client-id`       | Azure client ID for authentication (required when cloud-provider is `azure`) | ❌ No | —                      |
-| `azure-tenant-id`       | Azure tenant ID for authentication (required when cloud-provider is `azure`) | ❌ No | —                      |
-| `azure-subscription-id` | Azure subscription ID for authentication (required when cloud-provider is `azure`) | ❌ No | —                      |
 
 ### 🔐 Secrets
 
 | Name                    | Description                                                      | Required When           |
 |-------------------------|------------------------------------------------------------------|-------------------------|
 | `tfc-token`             | HCP Terraform Cloud API token                                   | `backend-type` = `remote` |
+| `aws-role-to-assume`    | AWS IAM role ARN to assume                                       | `cloud-provider` = `aws` |
+| `gcp-wif-provider`      | GCP Workload Identity Federation provider                        | `cloud-provider` = `gcp` |
+| `azure-client-id`       | Azure client ID for authentication                               | `cloud-provider` = `azure` |
+| `azure-tenant-id`       | Azure tenant ID for authentication                               | `cloud-provider` = `azure` |
+| `azure-subscription-id` | Azure subscription ID for authentication                         | `cloud-provider` = `azure` |
 
 ---
 
@@ -95,9 +95,10 @@ jobs:
       tflint-ver: "v0.50.0"
       backend-type: s3
       aws-region: us-east-1
-      aws-role-to-assume: "arn:aws:iam::123456789012:role/terraform-role"
       terraform-dir: tf
       tf-vars-file: terraform.tfvars
+    secrets:
+      aws-role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 ```
 
 ### GCP with HCP Terraform Cloud Backend
@@ -118,12 +119,12 @@ jobs:
       cloud-provider: gcp
       tflint-ver: "v0.50.0"
       backend-type: remote
-      gcp-wif-provider: "projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider"
       gcp-service-account: "terraform@my-project.iam.gserviceaccount.com"
       terraform-dir: tf
       tf-vars-file: gcp.tfvars
     secrets:
       tfc-token: ${{ secrets.TFC_TOKEN }}
+      gcp-wif-provider: ${{ secrets.GCP_WIF_PROVIDER }}
 ```
 
 ### Azure with S3 Backend
@@ -146,9 +147,10 @@ jobs:
       backend-type: s3
       terraform-dir: tf
       tf-vars-file: azure.tfvars
-      azure-client-id: "your-azure-client-id"
-      azure-tenant-id: "your-azure-tenant-id"
-      azure-subscription-id: "your-azure-subscription-id"
+    secrets:
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 ```
 
 ## 🏗️ Directory Structure

--- a/README.md
+++ b/README.md
@@ -1,21 +1,33 @@
-# 🚀 Terraform CI/CD Reusable GitHub Action
+# 🚀 Terraform Multi-Cloud CI Reusable GitHub Action
 
-![Release](https://github.com/subhamay-bhattacharyya-gha/tf-ci-reusable-wf/actions/workflows/release.yaml/badge.svg)&nbsp;![Commit Activity](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Last Commit](https://img.shields.io/github/last-commit/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Release Date](https://img.shields.io/github/release-date/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Repo Size](https://img.shields.io/github/repo-size/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![File Count](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Issues](https://img.shields.io/github/issues/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Top Language](https://img.shields.io/github/languages/top/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Custom Endpoint](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/e888b11add51c19433dd459ff2103354/raw/400755ef0c8db8edbba8e782a17e244a96bde388/tf-ci-reusable-wf.json?)
+![Release](https://github.com/subhamay-bhattacharyya-gha/tf-ci-reusable-wf/actions/workflows/release.yaml/badge.svg)&nbsp;![Commit Activity](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Last Commit](https://img.shields.io/github/last-commit/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Release Date](https://img.shields.io/github/release-date/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Repo Size](https://img.shields.io/github/repo-size/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![File Count](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Issues](https://img.shields.io/github/issues/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Top Language](https://img.shields.io/github/languages/top/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Custom Endpoint](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/c09973adc852b754ba9bdae2ebce9678/raw/tf-ci-reusable-wf.json?)
 
-A reusable GitHub Actions workflow for running full CI/CD pipelines on Terraform-based infrastructure. This composite workflow performs validation, linting, cost estimation, metadata tagging, and resource builds with support for AWS and Infracost integrations.
+A reusable GitHub Actions workflow for running Terraform CI pipelines across multiple cloud providers (AWS, GCP, Azure). This workflow performs linting, validation, and planning with support for multiple backend types and authentication methods.
 
 ---
 
 ## 🧾 Action Description
 
-This GitHub Action:
+This GitHub Action provides a reusable workflow that:
 
-- Detects infrastructure and service changes
-- Performs security scans and IaC checks (Checkov, TFLint)
-- Tags Terraform resources using Yor
-- Executes Terraform commands (init, validate, plan, apply, destroy)
-- Estimates infrastructure cost with Infracost
-- Builds packages for Lambda, Glue, Step Functions (if applicable)
+- **Multi-cloud support**: Works with AWS, GCP, and Azure infrastructure
+- **Terraform linting**: Uses TFLint for code quality checks
+- **Terraform validation**: Validates configuration syntax and consistency
+- **Terraform planning**: Generates execution plans for infrastructure changes
+- **Flexible backends**: Supports S3 and HCP Terraform Cloud backends
+- **Secure authentication**: Uses cloud-native authentication methods (IAM roles, Workload Identity, etc.)
+
+### Current Pipeline Steps
+
+1. **🔍 TFLint**: Lints Terraform code for best practices and errors
+2. **✅ Validate**: Validates Terraform configuration files
+3. **🔍 Plan**: Creates Terraform execution plan
+
+### Planned Enhancements
+
+- Checkov security scanning
+- Infracost cost estimation
+- Automated release tagging
 
 ---
 
@@ -23,75 +35,136 @@ This GitHub Action:
 
 | Name             | Description                                                                 | Required | Default               |
 |------------------|-----------------------------------------------------------------------------|----------|------------------------|
-| `environment`     | Environment to deploy to (`ci`, `devl`, `test`, `prod`)                    | ✅ Yes   | —                      |
-| `terraform-dir`   | Directory containing Terraform configuration files                         | ✅ Yes   | `tf`                   |
-| `tf-vars-file`    | Terraform variables file to use                                            | ❌ No    | `terraform.tfvars`     |
-| `ci-pipeline`     | Whether this is a CI pipeline run                                          | ❌ No    | `true`                 |
+| `cloud-provider` | Target cloud provider (`aws`, `gcp`, `azure`)                             | ✅ Yes   | —                      |
+| `tflint-ver`     | TFLint version to install                                                  | ✅ Yes   | —                      |
+| `backend-type`   | Backend type: `s3` for AWS S3 or `remote` for HCP Terraform Cloud         | ❌ No    | `s3`                   |
+| `aws-region`     | AWS region for authentication (required when cloud-provider is `aws`)     | ❌ No    | —                      |
+| `tf-vars-file`   | Terraform variables file to use                                            | ❌ No    | `terraform.tfvars`     |
 
 ### 🔐 Secrets
 
-| Name                 | Description                                 | Required |
-|----------------------|---------------------------------------------|----------|
-| `aws-role-arn`       | AWS role ARN to assume                      | ✅ Yes   |
-| `infracost-api-key`  | API key for Infracost                       | ✅ Yes   |
-| `infracost-gist-id`  | Gist ID to store Infracost results          | ✅ Yes   |
+| Name                    | Description                                                      | Required When           |
+|-------------------------|------------------------------------------------------------------|-------------------------|
+| `tfc-token`             | HCP Terraform Cloud API token                                   | `backend-type` = `remote` |
+| `aws-role-to-assume`    | AWS IAM role ARN to assume                                       | `cloud-provider` = `aws` |
+| `gcp-wif-provider`      | GCP Workload Identity Federation provider                        | `cloud-provider` = `gcp` |
+| `gcp-service-account`   | GCP service account email for authentication                     | `cloud-provider` = `gcp` |
+| `azure-client-id`       | Azure client ID for authentication                               | `cloud-provider` = `azure` |
+| `azure-tenant-id`       | Azure tenant ID for authentication                               | `cloud-provider` = `azure` |
+| `azure-subscription-id` | Azure subscription ID for authentication                         | `cloud-provider` = `azure` |
 
 ---
 
-## 📊 Workflow Overview (Mermaid)
+## 📊 Workflow Overview
 
 ```mermaid
 flowchart TD
-    A[Trigger via workflow_call] --> B[🔎 Check Environments]
-    A --> C[🔎 Detect Changes]
-    A --> D[🔎 Detect Services]
-    A --> E[🔎 Check Branch Issue]
-    B & C & D & E --> F[🧠 Determine Execution Path]
+    A[Trigger via workflow_call] --> B[� Validatev Cloud Provider]
+    B --> C[⚙️ TFLint]
+    C --> D[✅ Terraform Validate]
+    D --> E[� Terraforam Plan]
     
-    F --> G{Contains IaC?}
-    G -- Yes --> H[✔️ Terraform Validate]
-    G -- Yes --> I[📋 Terraform Lint]
-    G -- Yes --> J[🧳 Checkov Scan]
-    G -- Yes --> K[📋 Yor Tagging]
-    K --> L[📋 Terraform Plan]
-    L --> M[💰 Infracost]
-    M --> N[🚧 Terraform Apply]
-    N --> O[✂️ Terraform Destroy]
-
-    F --> P{Builds Required?}
-    P -- Lambda --> Q[🛠️ Lambda Package]
-    P -- Lambda Layer --> R[🛠️ Lambda Layer]
-    P -- Glue --> S[🛠️ Glue Script]
-    P -- Step Function --> T[🛠️ State Machine]
-
-    Q & R & S & T & O --> U[🚀 Create Pull Request]
+    F[Print Inputs] --> B
+    
+    style C fill:#e1f5fe
+    style D fill:#f3e5f5
+    style E fill:#fff3e0
 ```
 
 ---
 
-## Example Usage
+## 💡 Example Usage
+
+### AWS with S3 Backend
 
 ```yaml
-name: Terraform CI
+name: Terraform CI - AWS
 
 on:
+  push:
+    branches: ['**']
   pull_request:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
-  call-terraform-ci:
+  terraform-ci:
     uses: subhamay-bhattacharyya-gha/tf-ci-reusable-wf/.github/workflows/ci.yaml@main
     with:
-      environment: devl
-      terraform-dir: tf
-      tf-vars-file: dev.tfvars
-      ci-pipeline: true
+      cloud-provider: aws
+      tflint-ver: "v0.50.0"
+      backend-type: s3
+      aws-region: us-east-1
+      tf-vars-file: terraform.tfvars
     secrets:
-      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-      infracost-api-key: ${{ secrets.INFRACOST_API_KEY }}
-      infracost-gist-id: ${{ secrets.INFRACOST_GIST_ID }}
+      aws-role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+```
 
+### GCP with HCP Terraform Cloud Backend
+
+```yaml
+name: Terraform CI - GCP
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  terraform-ci:
+    uses: subhamay-bhattacharyya-gha/tf-ci-reusable-wf/.github/workflows/ci.yaml@main
+    with:
+      cloud-provider: gcp
+      tflint-ver: "v0.50.0"
+      backend-type: remote
+      tf-vars-file: gcp.tfvars
+    secrets:
+      tfc-token: ${{ secrets.TFC_TOKEN }}
+      gcp-wif-provider: ${{ secrets.GCP_WIF_PROVIDER }}
+      gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+```
+
+### Azure with S3 Backend
+
+```yaml
+name: Terraform CI - Azure
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  terraform-ci:
+    uses: subhamay-bhattacharyya-gha/tf-ci-reusable-wf/.github/workflows/ci.yaml@main
+    with:
+      cloud-provider: azure
+      tflint-ver: "v0.50.0"
+      backend-type: s3
+      tf-vars-file: azure.tfvars
+    secrets:
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+```
+
+## 🏗️ Directory Structure
+
+The workflow expects your repository to follow this structure:
+
+```
+your-repo/
+├── infra/
+│   ├── aws/
+│   │   └── tf/          # AWS Terraform files
+│   ├── gcp/
+│   │   └── tf/          # GCP Terraform files
+│   └── azure/
+│       └── tf/          # Azure Terraform files
+└── .github/
+    └── workflows/
+        └── main.yaml    # Your workflow that calls this reusable workflow
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -33,25 +33,26 @@ This GitHub Action provides a reusable workflow that:
 
 ## 🔧 Inputs
 
-| Name             | Description                                                                 | Required | Default               |
-|------------------|-----------------------------------------------------------------------------|----------|------------------------|
-| `cloud-provider` | Target cloud provider (`aws`, `gcp`, `azure`)                             | ✅ Yes   | —                      |
-| `tflint-ver`     | TFLint version to install                                                  | ✅ Yes   | —                      |
-| `backend-type`   | Backend type: `s3` for AWS S3 or `remote` for HCP Terraform Cloud         | ❌ No    | `s3`                   |
-| `aws-region`     | AWS region for authentication (required when cloud-provider is `aws`)     | ❌ No    | —                      |
-| `tf-vars-file`   | Terraform variables file to use                                            | ❌ No    | `terraform.tfvars`     |
+| Name                    | Description                                                                 | Required | Default               |
+|-------------------------|-----------------------------------------------------------------------------|----------|------------------------|
+| `cloud-provider`        | Target cloud provider (`aws`, `gcp`, `azure`)                             | ✅ Yes   | —                      |
+| `tflint-ver`            | TFLint version to install                                                  | ✅ Yes   | —                      |
+| `backend-type`          | Backend type: `s3` for AWS S3 or `remote` for HCP Terraform Cloud         | ❌ No    | `s3`                   |
+| `aws-region`            | AWS region for authentication (required when cloud-provider is `aws`)     | ❌ No    | —                      |
+| `aws-role-to-assume`    | AWS IAM role ARN to assume (required when cloud-provider is `aws`)        | ❌ No    | —                      |
+| `gcp-wif-provider`      | GCP Workload Identity Federation provider (required when cloud-provider is `gcp`) | ❌ No | —                      |
+| `gcp-service-account`   | GCP service account email for authentication (required when cloud-provider is `gcp`) | ❌ No | —                      |
+| `terraform-dir`         | Directory containing Terraform configuration files relative to cloud provider path | ❌ No | `tf`                   |
+| `tf-vars-file`          | Terraform variables file to use                                            | ❌ No    | `terraform.tfvars`     |
+| `azure-client-id`       | Azure client ID for authentication (required when cloud-provider is `azure`) | ❌ No | —                      |
+| `azure-tenant-id`       | Azure tenant ID for authentication (required when cloud-provider is `azure`) | ❌ No | —                      |
+| `azure-subscription-id` | Azure subscription ID for authentication (required when cloud-provider is `azure`) | ❌ No | —                      |
 
 ### 🔐 Secrets
 
 | Name                    | Description                                                      | Required When           |
 |-------------------------|------------------------------------------------------------------|-------------------------|
 | `tfc-token`             | HCP Terraform Cloud API token                                   | `backend-type` = `remote` |
-| `aws-role-to-assume`    | AWS IAM role ARN to assume                                       | `cloud-provider` = `aws` |
-| `gcp-wif-provider`      | GCP Workload Identity Federation provider                        | `cloud-provider` = `gcp` |
-| `gcp-service-account`   | GCP service account email for authentication                     | `cloud-provider` = `gcp` |
-| `azure-client-id`       | Azure client ID for authentication                               | `cloud-provider` = `azure` |
-| `azure-tenant-id`       | Azure tenant ID for authentication                               | `cloud-provider` = `azure` |
-| `azure-subscription-id` | Azure subscription ID for authentication                         | `cloud-provider` = `azure` |
 
 ---
 
@@ -94,9 +95,9 @@ jobs:
       tflint-ver: "v0.50.0"
       backend-type: s3
       aws-region: us-east-1
+      aws-role-to-assume: "arn:aws:iam::123456789012:role/terraform-role"
+      terraform-dir: tf
       tf-vars-file: terraform.tfvars
-    secrets:
-      aws-role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 ```
 
 ### GCP with HCP Terraform Cloud Backend
@@ -117,11 +118,12 @@ jobs:
       cloud-provider: gcp
       tflint-ver: "v0.50.0"
       backend-type: remote
+      gcp-wif-provider: "projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider"
+      gcp-service-account: "terraform@my-project.iam.gserviceaccount.com"
+      terraform-dir: tf
       tf-vars-file: gcp.tfvars
     secrets:
       tfc-token: ${{ secrets.TFC_TOKEN }}
-      gcp-wif-provider: ${{ secrets.GCP_WIF_PROVIDER }}
-      gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 ```
 
 ### Azure with S3 Backend
@@ -142,11 +144,11 @@ jobs:
       cloud-provider: azure
       tflint-ver: "v0.50.0"
       backend-type: s3
+      terraform-dir: tf
       tf-vars-file: azure.tfvars
-    secrets:
-      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure-client-id: "your-azure-client-id"
+      azure-tenant-id: "your-azure-tenant-id"
+      azure-subscription-id: "your-azure-subscription-id"
 ```
 
 ## 🏗️ Directory Structure


### PR DESCRIPTION
This pull request updates the documentation and CI workflows to better support multi-cloud Terraform CI pipelines and to improve notification capabilities. The most significant changes include a major rewrite of the `README.md` for clarity and multi-cloud support, the addition of a Slack notification workflow, and minor workflow naming adjustments.

**Documentation improvements:**

* Overhauled the `README.md` to focus on multi-cloud (AWS, GCP, Azure) Terraform CI support, clarified pipeline steps, inputs, secrets, and provided concrete usage examples for each cloud provider. The planned enhancements and expected directory structure are also described.

**CI/CD workflow enhancements:**

* Added a new `.github/workflows/notify.yaml` workflow that triggers Slack notifications when pull requests or issues are opened, using a reusable workflow and secrets for the Slack webhook.
* Renamed the `.github/workflows/create-branch.yaml` workflow from "Auto Create Branch on Issue Assignment" to "Auto Create Branch" for clarity.