### PR TITLE
ci(workflows): move GCP service account from inputs to secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,12 +25,6 @@ on:
         required: false
         type: string
 
-      # GCP Authentication Inputs
-      gcp-service-account:
-        description: "GCP service account email for authentication. Required when cloud-provider is 'gcp'."
-        required: false
-        type: string
-
       # Azure Authentication Inputs
       terraform-dir:
         description: "Directory containing Terraform configuration files relative to cloud provider path"
@@ -58,6 +52,10 @@ on:
       # GCP Authentication Secret
       gcp-wif-provider:
         description: "GCP Workload Identity Federation provider. Required when cloud-provider is 'gcp'."
+        required: false
+
+      gcp-service-account:
+        description: "GCP service account email for authentication. Required when cloud-provider is 'gcp'."
         required: false
 
       # Azure Authentication Secrets
@@ -95,7 +93,7 @@ jobs:
           echo "AWS Region: ${{ inputs.aws-region }}"
           echo "AWS Role to Assume: ${{ secrets.aws-role-to-assume && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "GCP WIF Provider: ${{ secrets.gcp-wif-provider && '[PROVIDED]' || '[NOT PROVIDED]' }}"
-          echo "GCP Service Account: ${{ inputs.gcp-service-account }}"
+          echo "GCP Service Account: ${{ secrets.gcp-service-account && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "Azure Client ID: ${{ secrets.azure-client-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "Azure Tenant ID: ${{ secrets.azure-tenant-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "Azure Subscription ID: ${{ secrets.azure-subscription-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
@@ -146,7 +144,7 @@ jobs:
           aws-region: ${{ inputs.aws-region }}
           aws-role-to-assume: ${{ secrets.aws-role-to-assume }}
           gcp-wif-provider: ${{ secrets.gcp-wif-provider }}
-          gcp-service-account: ${{ inputs.gcp-service-account }}
+          gcp-service-account: ${{ secrets.gcp-service-account }}
           azure-client-id: ${{ secrets.azure-client-id }}
           azure-tenant-id: ${{ secrets.azure-tenant-id }}
           azure-subscription-id: ${{ secrets.azure-subscription-id }}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ This GitHub Action provides a reusable workflow that:
 | `tflint-ver`            | TFLint version to install                                                  | ✅ Yes   | —                      |
 | `backend-type`          | Backend type: `s3` for AWS S3 or `remote` for HCP Terraform Cloud         | ❌ No    | `s3`                   |
 | `aws-region`            | AWS region for authentication (required when cloud-provider is `aws`)     | ❌ No    | —                      |
-| `gcp-service-account`   | GCP service account email for authentication (required when cloud-provider is `gcp`) | ❌ No | —                      |
 | `terraform-dir`         | Directory containing Terraform configuration files relative to cloud provider path | ❌ No | `tf`                   |
 | `tf-vars-file`          | Terraform variables file to use                                            | ❌ No    | `terraform.tfvars`     |
 
@@ -50,6 +49,7 @@ This GitHub Action provides a reusable workflow that:
 | `tfc-token`             | HCP Terraform Cloud API token                                   | `backend-type` = `remote` |
 | `aws-role-to-assume`    | AWS IAM role ARN to assume                                       | `cloud-provider` = `aws` |
 | `gcp-wif-provider`      | GCP Workload Identity Federation provider                        | `cloud-provider` = `gcp` |
+| `gcp-service-account`   | GCP service account email for authentication                     | `cloud-provider` = `gcp` |
 | `azure-client-id`       | Azure client ID for authentication                               | `cloud-provider` = `azure` |
 | `azure-tenant-id`       | Azure tenant ID for authentication                               | `cloud-provider` = `azure` |
 | `azure-subscription-id` | Azure subscription ID for authentication                         | `cloud-provider` = `azure` |
@@ -119,12 +119,12 @@ jobs:
       cloud-provider: gcp
       tflint-ver: "v0.50.0"
       backend-type: remote
-      gcp-service-account: "terraform@my-project.iam.gserviceaccount.com"
       terraform-dir: tf
       tf-vars-file: gcp.tfvars
     secrets:
       tfc-token: ${{ secrets.TFC_TOKEN }}
       gcp-wif-provider: ${{ secrets.GCP_WIF_PROVIDER }}
+      gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 ```
 
 ### Azure with S3 Backend


### PR DESCRIPTION
- Move gcp-service-account from workflow inputs to secrets section
- Reorder GCP authentication secrets for consistency
- Update ci.yaml debug output to mask gcp-service-account value
- Update workflow call to pass gcp-service-account as secret instead of input
- Update README.md to reflect gcp-service-account as a secret parameter
- Update usage example to pass gcp-service-account via secrets
- Improves security by treating sensitive GCP credentials as secrets rather than inputs