### PR TITLE
feat: Add support for Databricks and Snowflake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       cloud-provider:
-        description: "Target cloud provider (aws, gcp, azure)"
+        description: "Target cloud provider (aws, gcp, azure, snowflake)"
         required: true
         type: string
       tflint-ver:
@@ -22,6 +22,22 @@ on:
       # AWS Authentication Inputs
       aws-region:
         description: "AWS region for authentication. Required when cloud-provider is 'aws'."
+        required: false
+        type: string
+
+      # Snowflake Authentication Inputs
+      snowflake-account:
+        description: "Snowflake account identifier. Required when cloud-provider is 'snowflake'."
+        required: false
+        type: string
+
+      snowflake-user:
+        description: "Snowflake user name. Required when cloud-provider is 'snowflake'."
+        required: false
+        type: string
+
+      snowflake-role:
+        description: "Snowflake role name. Required when cloud-provider is 'snowflake'."
         required: false
         type: string
 
@@ -56,6 +72,11 @@ on:
 
       gcp-service-account:
         description: "GCP service account email for authentication. Required when cloud-provider is 'gcp'."
+        required: false
+
+      # Snowflake Authentication Secret
+      snowflake-private-key:
+        description: "Snowflake private key for authentication. Required when cloud-provider is 'snowflake'."
         required: false
 
       # Azure Authentication Secrets
@@ -101,8 +122,8 @@ jobs:
 
       - name: Validate Cloud Provider
         run: |
-          if [[ "${{ inputs.cloud-provider }}" != "aws" && "${{ inputs.cloud-provider }}" != "gcp" && "${{ inputs.cloud-provider }}" != "azure" ]]; then
-            echo "Error: Invalid cloud provider '${{ inputs.cloud-provider }}'. Must be one of: aws, gcp, azure"
+          if [[ "${{ inputs.cloud-provider }}" != "aws" && "${{ inputs.cloud-provider }}" != "gcp" && "${{ inputs.cloud-provider }}" != "azure" && "${{ inputs.cloud-provider }}" != "snowflake" ]]; then
+            echo "Error: Invalid cloud provider '${{ inputs.cloud-provider }}'. Must be one of: aws, gcp, azure, snowflake"
             exit 1
           fi
           echo "Valid cloud provider: ${{ inputs.cloud-provider }}"
@@ -145,6 +166,10 @@ jobs:
           aws-role-to-assume: ${{ secrets.aws-role-to-assume }}
           gcp-wif-provider: ${{ secrets.gcp-wif-provider }}
           gcp-service-account: ${{ secrets.gcp-service-account }}
+          snowflake-account: ${{ inputs.snowflake-account }}
+          snowflake-user: ${{ inputs.snowflake-user }}
+          snowflake-role: ${{ inputs.snowflake-role }}
+          snowflake-private-key: ${{ secrets.snowflake-private-key }}
           azure-client-id: ${{ secrets.azure-client-id }}
           azure-tenant-id: ${{ secrets.azure-tenant-id }}
           azure-subscription-id: ${{ secrets.azure-subscription-id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       cloud-provider:
-        description: "Target cloud provider (aws, gcp, azure, snowflake)"
+        description: "Target cloud provider (aws, gcp, azure, snowflake, databricks)"
         required: true
         type: string
       tflint-ver:
@@ -79,6 +79,15 @@ on:
         description: "Snowflake private key for authentication. Required when cloud-provider is 'snowflake'."
         required: false
 
+      # Databricks Authentication Secrets
+      databricks-host:
+        description: "Databricks workspace URL. Required when cloud-provider is 'databricks'."
+        required: false
+
+      databricks-token:
+        description: "Databricks personal access token. Required when cloud-provider is 'databricks'."
+        required: false
+
       # Azure Authentication Secrets
       azure-client-id:
         description: "Azure client ID for authentication. Required when cloud-provider is 'azure'."
@@ -115,6 +124,12 @@ jobs:
           echo "AWS Role to Assume: ${{ secrets.aws-role-to-assume && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "GCP WIF Provider: ${{ secrets.gcp-wif-provider && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "GCP Service Account: ${{ secrets.gcp-service-account && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "Snowflake Account: ${{ inputs.snowflake-account }}"
+          echo "Snowflake User: ${{ inputs.snowflake-user }}"
+          echo "Snowflake Role: ${{ inputs.snowflake-role }}"
+          echo "Snowflake Private Key: ${{ secrets.snowflake-private-key && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "Databricks Host: ${{ secrets.databricks-host && '[PROVIDED]' || '[NOT PROVIDED]' }}"
+          echo "Databricks Token: ${{ secrets.databricks-token && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "Azure Client ID: ${{ secrets.azure-client-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "Azure Tenant ID: ${{ secrets.azure-tenant-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "Azure Subscription ID: ${{ secrets.azure-subscription-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
@@ -122,11 +137,96 @@ jobs:
 
       - name: Validate Cloud Provider
         run: |
-          if [[ "${{ inputs.cloud-provider }}" != "aws" && "${{ inputs.cloud-provider }}" != "gcp" && "${{ inputs.cloud-provider }}" != "azure" && "${{ inputs.cloud-provider }}" != "snowflake" ]]; then
-            echo "Error: Invalid cloud provider '${{ inputs.cloud-provider }}'. Must be one of: aws, gcp, azure, snowflake"
+          # Validate cloud provider value
+          if [[ "${{ inputs.cloud-provider }}" != "aws" && "${{ inputs.cloud-provider }}" != "gcp" && "${{ inputs.cloud-provider }}" != "azure" && "${{ inputs.cloud-provider }}" != "snowflake" && "${{ inputs.cloud-provider }}" != "databricks" ]]; then
+            echo "Error: Invalid cloud provider '${{ inputs.cloud-provider }}'. Must be one of: aws, gcp, azure, snowflake, databricks"
             exit 1
           fi
           echo "Valid cloud provider: ${{ inputs.cloud-provider }}"
+          
+          # Validate AWS requirements
+          if [[ "${{ inputs.cloud-provider }}" == "aws" ]]; then
+            echo "Validating AWS requirements..."
+            if [[ -z "${{ inputs.aws-region }}" ]]; then
+              echo "Error: aws-region is required when cloud-provider is 'aws'"
+              exit 1
+            fi
+            if [[ -z "${{ secrets.aws-role-to-assume }}" ]]; then
+              echo "Error: aws-role-to-assume secret is required when cloud-provider is 'aws'"
+              exit 1
+            fi
+            echo "✓ AWS requirements validated"
+          fi
+          
+          # Validate GCP requirements
+          if [[ "${{ inputs.cloud-provider }}" == "gcp" ]]; then
+            echo "Validating GCP requirements..."
+            if [[ -z "${{ secrets.gcp-wif-provider }}" ]]; then
+              echo "Error: gcp-wif-provider secret is required when cloud-provider is 'gcp'"
+              exit 1
+            fi
+            if [[ -z "${{ secrets.gcp-service-account }}" ]]; then
+              echo "Error: gcp-service-account secret is required when cloud-provider is 'gcp'"
+              exit 1
+            fi
+            echo "✓ GCP requirements validated"
+          fi
+          
+          # Validate Azure requirements
+          if [[ "${{ inputs.cloud-provider }}" == "azure" ]]; then
+            echo "Validating Azure requirements..."
+            if [[ -z "${{ secrets.azure-client-id }}" ]]; then
+              echo "Error: azure-client-id secret is required when cloud-provider is 'azure'"
+              exit 1
+            fi
+            if [[ -z "${{ secrets.azure-tenant-id }}" ]]; then
+              echo "Error: azure-tenant-id secret is required when cloud-provider is 'azure'"
+              exit 1
+            fi
+            if [[ -z "${{ secrets.azure-subscription-id }}" ]]; then
+              echo "Error: azure-subscription-id secret is required when cloud-provider is 'azure'"
+              exit 1
+            fi
+            echo "✓ Azure requirements validated"
+          fi
+          
+          # Validate Snowflake requirements
+          if [[ "${{ inputs.cloud-provider }}" == "snowflake" ]]; then
+            echo "Validating Snowflake requirements..."
+            if [[ -z "${{ inputs.snowflake-account }}" ]]; then
+              echo "Error: snowflake-account is required when cloud-provider is 'snowflake'"
+              exit 1
+            fi
+            if [[ -z "${{ inputs.snowflake-user }}" ]]; then
+              echo "Error: snowflake-user is required when cloud-provider is 'snowflake'"
+              exit 1
+            fi
+            if [[ -z "${{ inputs.snowflake-role }}" ]]; then
+              echo "Error: snowflake-role is required when cloud-provider is 'snowflake'"
+              exit 1
+            fi
+            if [[ -z "${{ secrets.snowflake-private-key }}" ]]; then
+              echo "Error: snowflake-private-key secret is required when cloud-provider is 'snowflake'"
+              exit 1
+            fi
+            echo "✓ Snowflake requirements validated"
+          fi
+          
+          # Validate Databricks requirements
+          if [[ "${{ inputs.cloud-provider }}" == "databricks" ]]; then
+            echo "Validating Databricks requirements..."
+            if [[ -z "${{ secrets.databricks-host }}" ]]; then
+              echo "Error: databricks-host secret is required when cloud-provider is 'databricks'"
+              exit 1
+            fi
+            if [[ -z "${{ secrets.databricks-token }}" ]]; then
+              echo "Error: databricks-token secret is required when cloud-provider is 'databricks'"
+              exit 1
+            fi
+            echo "✓ Databricks requirements validated"
+          fi
+          
+          echo "All validations passed successfully!"
 
       - name: Run TFLint
         uses: subhamay-bhattacharyya-gha/tf-lint-action@main
@@ -170,6 +270,8 @@ jobs:
           snowflake-user: ${{ inputs.snowflake-user }}
           snowflake-role: ${{ inputs.snowflake-role }}
           snowflake-private-key: ${{ secrets.snowflake-private-key }}
+          databricks-host: ${{ secrets.databricks-host }}
+          databricks-token: ${{ secrets.databricks-token }}
           azure-client-id: ${{ secrets.azure-client-id }}
           azure-tenant-id: ${{ secrets.azure-tenant-id }}
           azure-subscription-id: ${{ secrets.azure-subscription-id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: Terraform Multi-Cloud CI Build
 on:
   workflow_call:
     inputs:
+      # Cloud Provider Selection
       cloud-provider:
         description: "Target cloud provider (aws, gcp, azure, snowflake, databricks)"
         required: true
@@ -11,6 +12,11 @@ on:
         description: "TFLint version to install"
         required: true
         type: string
+      terraform-dir:
+        description: "Directory containing Terraform configuration files relative to cloud provider path"
+        required: false
+        type: string
+        default: "tf"
 
       # Backend Type Selection
       backend-type:
@@ -41,13 +47,6 @@ on:
         required: false
         type: string
 
-      # Azure Authentication Inputs
-      terraform-dir:
-        description: "Directory containing Terraform configuration files relative to cloud provider path"
-        required: false
-        type: string
-        default: "tf"
-      
       # Terraform artifacts
       tf-vars-file:
         description: "Optional Terraform variable file"
@@ -135,7 +134,9 @@ jobs:
           echo "Azure Subscription ID: ${{ secrets.azure-subscription-id && '[PROVIDED]' || '[NOT PROVIDED]' }}"
           echo "======================="
 
-      - name: Validate Cloud Provider
+      # Validate input configuration
+      #############################################
+      - name: Validate Input Configuration
         run: |
           # Validate cloud provider value
           if [[ "${{ inputs.cloud-provider }}" != "aws" && "${{ inputs.cloud-provider }}" != "gcp" && "${{ inputs.cloud-provider }}" != "azure" && "${{ inputs.cloud-provider }}" != "snowflake" && "${{ inputs.cloud-provider }}" != "databricks" ]]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ permissions:
 
 jobs:
   terraform-lint:
-    name: ⚙️ TFLint - ${{ inputs.cloud-provider }}
+    name: ⚙️ TFLint
     runs-on: ubuntu-latest
     
     steps:
@@ -137,7 +137,7 @@ jobs:
           tflint-format: "compact"
 
   terraform-validate:
-    name: ✅ Validate - ${{ inputs.cloud-provider }}
+    name: ✅ Validate
     runs-on: ubuntu-latest
     needs: 
       - terraform-lint
@@ -149,14 +149,14 @@ jobs:
           terraform-dir: infra/${{ inputs.cloud-provider }}/${{ inputs.terraform-dir }}
 
   terraform-plan:
-    name: 🔍 Plan - ${{ inputs.cloud-provider }}
+    name: 🔍 Plan
     runs-on: ubuntu-latest
     needs: 
       - terraform-validate
 
     steps:
       - name: Terraform Plan 
-        uses: subhamay-bhattacharyya-gha/tf-plan-action@main
+        uses: subhamay-bhattacharyya-gha/tf-plan-action@feature/GHA-0044-enhancement-add-snowflake
         with:
           cloud-provider: ${{ inputs.cloud-provider }}
           terraform-dir: infra/${{ inputs.cloud-provider }}/${{ inputs.terraform-dir }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Release](https://github.com/subhamay-bhattacharyya-gha/tf-ci-reusable-wf/actions/workflows/release.yaml/badge.svg)&nbsp;![Commit Activity](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Last Commit](https://img.shields.io/github/last-commit/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Release Date](https://img.shields.io/github/release-date/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Repo Size](https://img.shields.io/github/repo-size/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![File Count](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Issues](https://img.shields.io/github/issues/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Top Language](https://img.shields.io/github/languages/top/subhamay-bhattacharyya-gha/tf-ci-reusable-wf)&nbsp;![Custom Endpoint](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/c09973adc852b754ba9bdae2ebce9678/raw/tf-ci-reusable-wf.json?)
 
-A reusable GitHub Actions workflow for running Terraform CI pipelines across multiple cloud providers (AWS, GCP, Azure, Snowflake). This workflow performs linting, validation, and planning with support for multiple backend types and authentication methods.
+A reusable GitHub Actions workflow for running Terraform CI pipelines across multiple cloud providers (AWS, GCP, Azure, Snowflake, Databricks). This workflow performs linting, validation, and planning with support for multiple backend types and authentication methods.
 
 ---
 
@@ -10,7 +10,7 @@ A reusable GitHub Actions workflow for running Terraform CI pipelines across mul
 
 This GitHub Action provides a reusable workflow that:
 
-- **Multi-cloud support**: Works with AWS, GCP, Azure, and Snowflake infrastructure
+- **Multi-cloud support**: Works with AWS, GCP, Azure, Snowflake, and Databricks infrastructure
 - **Terraform linting**: Uses TFLint for code quality checks
 - **Terraform validation**: Validates configuration syntax and consistency
 - **Terraform planning**: Generates execution plans for infrastructure changes
@@ -35,7 +35,7 @@ This GitHub Action provides a reusable workflow that:
 
 | Name                    | Description                                                                 | Required | Default               |
 |-------------------------|-----------------------------------------------------------------------------|----------|------------------------|
-| `cloud-provider`        | Target cloud provider (`aws`, `gcp`, `azure`, `snowflake`)               | ✅ Yes   | —                      |
+| `cloud-provider`        | Target cloud provider (`aws`, `gcp`, `azure`, `snowflake`, `databricks`) | ✅ Yes   | —                      |
 | `tflint-ver`            | TFLint version to install                                                  | ✅ Yes   | —                      |
 | `backend-type`          | Backend type: `s3` for AWS S3 or `remote` for HCP Terraform Cloud         | ❌ No    | `s3`                   |
 | `aws-region`            | AWS region for authentication (required when cloud-provider is `aws`)     | ❌ No    | —                      |
@@ -54,6 +54,8 @@ This GitHub Action provides a reusable workflow that:
 | `gcp-wif-provider`      | GCP Workload Identity Federation provider                        | `cloud-provider` = `gcp` |
 | `gcp-service-account`   | GCP service account email for authentication                     | `cloud-provider` = `gcp` |
 | `snowflake-private-key` | Snowflake private key for authentication                         | `cloud-provider` = `snowflake` |
+| `databricks-host`       | Databricks workspace URL                                         | `cloud-provider` = `databricks` |
+| `databricks-token`      | Databricks personal access token                                 | `cloud-provider` = `databricks` |
 | `azure-client-id`       | Azure client ID for authentication                               | `cloud-provider` = `azure` |
 | `azure-tenant-id`       | Azure tenant ID for authentication                               | `cloud-provider` = `azure` |
 | `azure-subscription-id` | Azure subscription ID for authentication                         | `cloud-provider` = `azure` |
@@ -184,6 +186,31 @@ jobs:
       snowflake-private-key: ${{ secrets.SNOWFLAKE_PRIVATE_KEY }}
 ```
 
+### Databricks with S3 Backend
+
+```yaml
+name: Terraform CI - Databricks
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  terraform-ci:
+    uses: subhamay-bhattacharyya-gha/tf-ci-reusable-wf/.github/workflows/ci.yaml@main
+    with:
+      cloud-provider: databricks
+      tflint-ver: "v0.50.0"
+      backend-type: s3
+      terraform-dir: tf
+      tf-vars-file: databricks.tfvars
+    secrets:
+      databricks-host: ${{ secrets.DATABRICKS_HOST }}
+      databricks-token: ${{ secrets.DATABRICKS_TOKEN }}
+```
+
 ## 🏗️ Directory Structure
 
 The workflow expects your repository to follow this structure:
@@ -197,8 +224,10 @@ your-repo/
 │   │   └── tf/          # GCP Terraform files
 │   ├── azure/
 │   │   └── tf/          # Azure Terraform files
-│   └── snowflake/
-│       └── tf/          # Snowflake Terraform files
+│   ├── snowflake/
+│   │   └── tf/          # Snowflake Terraform files
+│   └── databricks/
+│       └── tf/          # Databricks Terraform files
 └── .github/
     └── workflows/
         └── main.yaml    # Your workflow that calls this reusable workflow


### PR DESCRIPTION
This pull request extends the Terraform CI reusable GitHub Actions workflow to support Snowflake and Databricks as additional cloud providers, alongside AWS, GCP, and Azure. It introduces new input parameters and secrets for authenticating with these providers, updates validation logic, and enhances documentation with usage examples and directory structure updates.

**Multi-cloud support and input validation:**

- Added support for `snowflake` and `databricks` as valid values for the `cloud-provider` input, including new required parameters and secrets for authentication (e.g., `snowflake-account`, `snowflake-user`, `snowflake-role`, `snowflake-private-key`, `databricks-host`, `databricks-token`). (.github/workflows/ci.yaml) [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR6-R19) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL28-L33) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR76-R89)
- Updated the input validation step to include checks for the new providers, ensuring all required parameters and secrets are present based on the selected cloud provider. (.github/workflows/ci.yaml)

**Workflow and job enhancements:**

- Updated job names to be more generic and adjusted the `terraform-plan` job to use a feature branch of the action that supports Snowflake. (.github/workflows/ci.yaml) [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL80-R109) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL119-R241) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL131-R260)
- Passed new Snowflake and Databricks parameters and secrets to the relevant jobs. (.github/workflows/ci.yaml)

**Documentation updates:**

- Updated the `README.md` to reflect support for Snowflake and Databricks, including new input/secrets tables, example workflow usage for both providers, and the expected directory structure for their configuration files. (README.md) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R44) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R58) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R162-R213) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L167-R230)