### PR TITLE
fix: update terraform plan action to use main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,7 +257,7 @@ jobs:
 
     steps:
       - name: Terraform Plan 
-        uses: subhamay-bhattacharyya-gha/tf-plan-action@feature/GHA-0044-enhancement-add-snowflake
+        uses: subhamay-bhattacharyya-gha/tf-plan-action@main
         with:
           cloud-provider: ${{ inputs.cloud-provider }}
           terraform-dir: infra/${{ inputs.cloud-provider }}/${{ inputs.terraform-dir }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use the stable `main` branch of the `tf-plan-action` instead of a feature branch. This change ensures that CI runs against the latest stable version of the Terraform plan action.

* Workflow stability:
  * [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL260-R260): Changed the `tf-plan-action` step to use the `main` branch instead of the `feature/GHA-0044-enhancement-add-snowflake` branch.- Update tf-plan-action reference from feature/GHA-0044-enhancement-add-snowflake to main branch
- Ensure CI pipeline uses stable version of terraform plan action
- Maintain consistency with production-ready workflow dependencies