### PR TITLE
feat: Enhance Snowflake input validation and update documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,17 +204,13 @@ jobs:
               fi
               ;;
             "snowflake")
-              if [[ -z "${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}" || -z "${{ vars.SNOWFLAKE_ACCOUNT_NAME }}" ]]; then
-                echo "Error: SNOWFLAKE_ORGANIZATION_NAME and SNOWFLAKE_ACCOUNT_NAME GitHub variables are required when cloud-provider is 'snowflake'"
-                exit 1
-              fi
               if [[ "${{ inputs.backend-type }}" != "remote" ]]; then
-                if [[ -z "${{ inputs.snowflake-user }}" || -z "${{ inputs.snowflake-role }}" || -z "${{ secrets.snowflake-private-key }}" ]]; then
-                  echo "Error: snowflake-user, snowflake-role, and snowflake-private-key are required when cloud-provider is 'snowflake' and backend-type is not 'remote'"
+                if [[ -z "${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}" || -z "${{ vars.SNOWFLAKE_ACCOUNT_NAME }}" || -z "${{ inputs.snowflake-user }}" || -z "${{ inputs.snowflake-role }}" || -z "${{ secrets.snowflake-private-key }}" ]]; then
+                  echo "Error: SNOWFLAKE_ORGANIZATION_NAME, SNOWFLAKE_ACCOUNT_NAME, snowflake-user, snowflake-role, and snowflake-private-key are required when cloud-provider is 'snowflake' and backend-type is not 'remote'"
                   exit 1
                 fi
               else
-                echo "ℹ️   backend-type=remote — delegating snowflake-user/role/private-key resolution to HCP variable set"
+                echo "ℹ️   backend-type=remote — delegating SNOWFLAKE_ORGANIZATION_NAME / SNOWFLAKE_ACCOUNT_NAME / snowflake-user / snowflake-role / snowflake-private-key to HCP variable set (any values supplied via GH vars/inputs will still override if non-empty)"
               fi
               ;;
             "databricks")
@@ -260,10 +256,10 @@ jobs:
               # Check for Snowflake directory
               if [[ -d "infra/snowflake" ]]; then
                 echo "Found infra/snowflake directory - validating Snowflake inputs..."
-                if [[ -z "${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}" || -z "${{ vars.SNOWFLAKE_ACCOUNT_NAME }}" ]]; then
-                  VALIDATION_ERRORS="${VALIDATION_ERRORS}\n- Snowflake: SNOWFLAKE_ORGANIZATION_NAME and SNOWFLAKE_ACCOUNT_NAME GitHub variables are required"
-                elif [[ "${{ inputs.backend-type }}" != "remote" ]] && [[ -z "${{ inputs.snowflake-user }}" || -z "${{ inputs.snowflake-role }}" || -z "${{ secrets.snowflake-private-key }}" ]]; then
-                  VALIDATION_ERRORS="${VALIDATION_ERRORS}\n- Snowflake: snowflake-user, snowflake-role, and snowflake-private-key are required when backend-type is not 'remote'"
+                if [[ "${{ inputs.backend-type }}" == "remote" ]]; then
+                  echo "  ℹ️   backend-type=remote — delegating Snowflake credentials to HCP variable set"
+                elif [[ -z "${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}" || -z "${{ vars.SNOWFLAKE_ACCOUNT_NAME }}" || -z "${{ inputs.snowflake-user }}" || -z "${{ inputs.snowflake-role }}" || -z "${{ secrets.snowflake-private-key }}" ]]; then
+                  VALIDATION_ERRORS="${VALIDATION_ERRORS}\n- Snowflake: SNOWFLAKE_ORGANIZATION_NAME, SNOWFLAKE_ACCOUNT_NAME, snowflake-user, snowflake-role, and snowflake-private-key are required when backend-type is not 'remote'"
                 else
                   echo "  ✅ Snowflake inputs validated"
                 fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,9 +204,17 @@ jobs:
               fi
               ;;
             "snowflake")
-              if [[ -z "${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}" || -z "${{ vars.SNOWFLAKE_ACCOUNT_NAME }}" || -z "${{ inputs.snowflake-user }}" || -z "${{ inputs.snowflake-role }}" || -z "${{ secrets.snowflake-private-key }}" ]]; then
-                echo "Error: snowflake-organization-name, snowflake-account-name, snowflake-user, snowflake-role, and snowflake-private-key are required when cloud-provider is 'snowflake'"
+              if [[ -z "${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}" || -z "${{ vars.SNOWFLAKE_ACCOUNT_NAME }}" ]]; then
+                echo "Error: SNOWFLAKE_ORGANIZATION_NAME and SNOWFLAKE_ACCOUNT_NAME GitHub variables are required when cloud-provider is 'snowflake'"
                 exit 1
+              fi
+              if [[ "${{ inputs.backend-type }}" != "remote" ]]; then
+                if [[ -z "${{ inputs.snowflake-user }}" || -z "${{ inputs.snowflake-role }}" || -z "${{ secrets.snowflake-private-key }}" ]]; then
+                  echo "Error: snowflake-user, snowflake-role, and snowflake-private-key are required when cloud-provider is 'snowflake' and backend-type is not 'remote'"
+                  exit 1
+                fi
+              else
+                echo "ℹ️   backend-type=remote — delegating snowflake-user/role/private-key resolution to HCP variable set"
               fi
               ;;
             "databricks")
@@ -252,8 +260,10 @@ jobs:
               # Check for Snowflake directory
               if [[ -d "infra/snowflake" ]]; then
                 echo "Found infra/snowflake directory - validating Snowflake inputs..."
-                if [[ -z "${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}" || -z "${{ vars.SNOWFLAKE_ACCOUNT_NAME }}" || -z "${{ inputs.snowflake-user }}" || -z "${{ inputs.snowflake-role }}" || -z "${{ secrets.snowflake-private-key }}" ]]; then
-                  VALIDATION_ERRORS="${VALIDATION_ERRORS}\n- Snowflake: snowflake-organization-name, snowflake-account-name, snowflake-user, snowflake-role, and snowflake-private-key are required"
+                if [[ -z "${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}" || -z "${{ vars.SNOWFLAKE_ACCOUNT_NAME }}" ]]; then
+                  VALIDATION_ERRORS="${VALIDATION_ERRORS}\n- Snowflake: SNOWFLAKE_ORGANIZATION_NAME and SNOWFLAKE_ACCOUNT_NAME GitHub variables are required"
+                elif [[ "${{ inputs.backend-type }}" != "remote" ]] && [[ -z "${{ inputs.snowflake-user }}" || -z "${{ inputs.snowflake-role }}" || -z "${{ secrets.snowflake-private-key }}" ]]; then
+                  VALIDATION_ERRORS="${VALIDATION_ERRORS}\n- Snowflake: snowflake-user, snowflake-role, and snowflake-private-key are required when backend-type is not 'remote'"
                 else
                   echo "  ✅ Snowflake inputs validated"
                 fi
@@ -315,14 +325,25 @@ jobs:
           echo "TF_VAR_git_commit_sha=${SHORT_SHA}" >> $GITHUB_ENV
           echo "TF_VAR_repository=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
 
-      - name: Set Snowflake Private Key
+      - name: Export Snowflake private key to GITHUB_ENV
         if: inputs.cloud-provider == 'snowflake' || inputs.cloud-provider == 'platform'
+        shell: bash
+        env:
+          SNOWFLAKE_PRIVATE_KEY: ${{ secrets.snowflake-private-key }}
         run: |
-          EOF_MARKER=$(openssl rand -hex 16)
-          echo "SNOWFLAKE_PRIVATE_KEY<<${EOF_MARKER}" >> $GITHUB_ENV
-          printf '%s' "${{ secrets.snowflake-private-key }}" >> $GITHUB_ENV
-          echo "" >> $GITHUB_ENV
-          echo "${EOF_MARKER}" >> $GITHUB_ENV
+          set -euo pipefail
+
+          KEY_FILE="/tmp/snowflake_key.p8"
+          printf '%b\n' "${SNOWFLAKE_PRIVATE_KEY}" > "${KEY_FILE}"
+          chmod 600 "${KEY_FILE}"
+
+          DELIM="EOF_$(openssl rand -hex 16)"
+          {
+            echo "SNOWFLAKE_PRIVATE_KEY<<${DELIM}"
+            cat "${KEY_FILE}"
+            echo ""
+            echo "${DELIM}"
+          } >> "${GITHUB_ENV}"
 
       - name: Debug Key Format
         if: inputs.cloud-provider == 'snowflake' || inputs.cloud-provider == 'platform'
@@ -340,6 +361,22 @@ jobs:
           echo "Line count:"
           echo "$SNOWFLAKE_PRIVATE_KEY" | wc -l
 
+      - name: Export Snowflake Terraform vars (only when provided)
+        if: inputs.cloud-provider == 'snowflake' || inputs.cloud-provider == 'platform'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.snowflake-user }}" ]]; then
+            echo "TF_VAR_snowflake_user=${{ inputs.snowflake-user }}" >> "$GITHUB_ENV"
+          else
+            echo "snowflake-user not supplied by caller — HCP variable set will own TF_VAR_snowflake_user"
+          fi
+          if [[ -n "${{ inputs.snowflake-role }}" ]]; then
+            echo "TF_VAR_snowflake_role=${{ inputs.snowflake-role }}" >> "$GITHUB_ENV"
+          else
+            echo "snowflake-role not supplied by caller — HCP variable set will own TF_VAR_snowflake_role"
+          fi
+
       - name: Terraform Plan
         uses: subhamay-bhattacharyya-gha/tf-plan-action@main
         env:
@@ -347,8 +384,6 @@ jobs:
           TF_VAR_databricks_token: ${{ secrets.databricks-token }}
           TF_VAR_snowflake_organization_name: ${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}
           TF_VAR_snowflake_account_name: ${{ vars.SNOWFLAKE_ACCOUNT_NAME }}
-          TF_VAR_snowflake_user: ${{ inputs.snowflake-user }}
-          TF_VAR_snowflake_role: ${{ inputs.snowflake-role }}
           SNOWFLAKE_PRIVATE_KEY: ${{ env.SNOWFLAKE_PRIVATE_KEY }}
         with:
           cloud-provider: ${{ inputs.cloud-provider }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -361,18 +361,39 @@ jobs:
           echo "Line count:"
           echo "$SNOWFLAKE_PRIVATE_KEY" | wc -l
 
-      - name: Export Snowflake Terraform vars (only when provided)
+      - name: Export Snowflake Terraform vars (sanitized)
         if: inputs.cloud-provider == 'snowflake' || inputs.cloud-provider == 'platform'
         shell: bash
+        env:
+          INPUT_SNOWFLAKE_USER: ${{ inputs.snowflake-user }}
+          INPUT_SNOWFLAKE_ROLE: ${{ inputs.snowflake-role }}
+          VAR_SNOWFLAKE_ORGANIZATION_NAME: ${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}
+          VAR_SNOWFLAKE_ACCOUNT_NAME: ${{ vars.SNOWFLAKE_ACCOUNT_NAME }}
         run: |
           set -euo pipefail
-          if [[ -n "${{ inputs.snowflake-user }}" ]]; then
-            echo "TF_VAR_snowflake_user=${{ inputs.snowflake-user }}" >> "$GITHUB_ENV"
+          # Strip CR/LF and trailing whitespace. GH variables entered via the UI
+          # occasionally carry a trailing CRLF which corrupts the Snowflake
+          # account URL (e.g. "account\r\n.snowflakecomputing.com" → "invalid URL escape %0D").
+          sanitize() { printf '%s' "$1" | tr -d '\r\n' | sed 's/[[:space:]]*$//'; }
+
+          ORG="$(sanitize "${VAR_SNOWFLAKE_ORGANIZATION_NAME}")"
+          ACCT="$(sanitize "${VAR_SNOWFLAKE_ACCOUNT_NAME}")"
+          USR="$(sanitize "${INPUT_SNOWFLAKE_USER}")"
+          ROLE="$(sanitize "${INPUT_SNOWFLAKE_ROLE}")"
+
+          if [[ -n "$ORG" ]]; then
+            echo "TF_VAR_snowflake_organization_name=$ORG" >> "$GITHUB_ENV"
+          fi
+          if [[ -n "$ACCT" ]]; then
+            echo "TF_VAR_snowflake_account_name=$ACCT" >> "$GITHUB_ENV"
+          fi
+          if [[ -n "$USR" ]]; then
+            echo "TF_VAR_snowflake_user=$USR" >> "$GITHUB_ENV"
           else
             echo "snowflake-user not supplied by caller — HCP variable set will own TF_VAR_snowflake_user"
           fi
-          if [[ -n "${{ inputs.snowflake-role }}" ]]; then
-            echo "TF_VAR_snowflake_role=${{ inputs.snowflake-role }}" >> "$GITHUB_ENV"
+          if [[ -n "$ROLE" ]]; then
+            echo "TF_VAR_snowflake_role=$ROLE" >> "$GITHUB_ENV"
           else
             echo "snowflake-role not supplied by caller — HCP variable set will own TF_VAR_snowflake_role"
           fi
@@ -382,8 +403,6 @@ jobs:
         env:
           TF_VAR_databricks_host: ${{ secrets.databricks-host }}
           TF_VAR_databricks_token: ${{ secrets.databricks-token }}
-          TF_VAR_snowflake_organization_name: ${{ vars.SNOWFLAKE_ORGANIZATION_NAME }}
-          TF_VAR_snowflake_account_name: ${{ vars.SNOWFLAKE_ACCOUNT_NAME }}
           SNOWFLAKE_PRIVATE_KEY: ${{ env.SNOWFLAKE_PRIVATE_KEY }}
         with:
           cloud-provider: ${{ inputs.cloud-provider }}

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ This GitHub Action provides a reusable workflow that:
 | `s3-bucket`             | S3 bucket name for Terraform state (required when backend-type is `s3`)   | ❌ No    | —                      |
 | `s3-region`             | AWS region for S3 bucket (required when backend-type is `s3`)             | ❌ No    | —                      |
 | `s3-key-prefix`         | S3 key prefix for Terraform state file (required when backend-type is `s3`) | ❌ No  | —                      |
-| `snowflake-user`        | Snowflake user name (required when cloud-provider is `snowflake`)         | ❌ No    | —                      |
-| `snowflake-role`        | Snowflake role name (required when cloud-provider is `snowflake`)         | ❌ No    | —                      |
+| `snowflake-user`        | Snowflake user name (required when `cloud-provider` is `snowflake` **and** `backend-type` is not `remote`; with `remote`, the HCP Terraform variable set supplies this) | ❌ No    | —                      |
+| `snowflake-role`        | Snowflake role name (required when `cloud-provider` is `snowflake` **and** `backend-type` is not `remote`; with `remote`, the HCP Terraform variable set supplies this) | ❌ No    | —                      |
 | `terraform-dir`         | Directory containing Terraform configuration files relative to cloud provider path | ❌ No | `tf`                   |
 | `tf-vars-file`          | Terraform variables file to use                                            | ❌ No    | `terraform.tfvars`     |
 
@@ -59,7 +59,7 @@ This GitHub Action provides a reusable workflow that:
 | Name                    | Description                                                      | Required When                  |
 |-------------------------|------------------------------------------------------------------|--------------------------------|
 | `tfc-token`             | HCP Terraform Cloud API token                                   | `backend-type` = `remote`      |
-| `snowflake-private-key` | Snowflake private key for authentication (base64 encoded)       | `cloud-provider` = `snowflake` |
+| `snowflake-private-key` | Snowflake private key for authentication (base64 encoded)       | `cloud-provider` = `snowflake` **and** `backend-type` ≠ `remote` (with `remote`, the HCP Terraform variable set supplies this) |
 | `databricks-host`       | Databricks workspace URL                                         | `cloud-provider` = `databricks` |
 | `databricks-token`      | Databricks personal access token                                 | `cloud-provider` = `databricks` |
 
@@ -250,6 +250,32 @@ jobs:
       snowflake-private-key: ${{ secrets.SNOWFLAKE_PRIVATE_KEY }}
 ```
 
+### Snowflake with HCP Terraform Cloud Backend
+
+When `backend-type` is `remote`, credentials (`snowflake-user`, `snowflake-role`, `snowflake-private-key`) are resolved from the HCP Terraform variable set. Omit them from the caller — passing empty values would override the variable set and cause authentication failures such as `260001: user is empty`.
+
+```yaml
+name: Terraform CI - Snowflake (HCP)
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  terraform-ci:
+    uses: subhamay-bhattacharyya-gha/tf-ci-reusable-wf/.github/workflows/ci.yaml@main
+    with:
+      environment: devl
+      cloud-provider: snowflake
+      tflint-ver: "v0.50.0"
+      backend-type: remote
+      tf-vars-file: snowflake.tfvars
+    secrets:
+      tfc-token: ${{ secrets.TFC_TOKEN }}
+```
+
 ### Databricks with S3 Backend
 
 ```yaml
@@ -350,7 +376,7 @@ The workflow performs comprehensive input validation before execution:
 - **AWS**: Requires `AWS_REGION` and `AWS_OIDC_ROLE` environment variables
 - **GCP**: Requires `GCP_WIF_PROVIDER` and `GCP_SERVICE_ACCOUNT` environment variables
 - **Azure**: Requires `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` environment variables
-- **Snowflake**: Requires `SNOWFLAKE_ORGANIZATION_NAME` and `SNOWFLAKE_ACCOUNT_NAME` environment variables, `snowflake-user` and `snowflake-role` inputs, and `snowflake-private-key` secret
+- **Snowflake**: Always requires `SNOWFLAKE_ORGANIZATION_NAME` and `SNOWFLAKE_ACCOUNT_NAME` environment variables. `snowflake-user`, `snowflake-role`, and `snowflake-private-key` are required **only when `backend-type` is not `remote`** — when `backend-type: remote`, these are delegated to the HCP Terraform variable set and any caller-supplied values are only forwarded if non-empty (empty values will not override the variable set)
 - **Databricks**: Requires `databricks-host` and `databricks-token` secrets
 - **Platform**: Validates inputs only for detected provider directories
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The following variables are read from the GitHub environment specified by the `e
 | `AZURE_CLIENT_ID`             | Azure client ID for authentication               | `cloud-provider` = `azure`    |
 | `AZURE_TENANT_ID`             | Azure tenant ID for authentication               | `cloud-provider` = `azure`    |
 | `AZURE_SUBSCRIPTION_ID`       | Azure subscription ID for authentication         | `cloud-provider` = `azure`    |
-| `SNOWFLAKE_ORGANIZATION_NAME` | Snowflake organization name                      | `cloud-provider` = `snowflake` |
-| `SNOWFLAKE_ACCOUNT_NAME`      | Snowflake account name                           | `cloud-provider` = `snowflake` |
+| `SNOWFLAKE_ORGANIZATION_NAME` | Snowflake organization name                      | `cloud-provider` = `snowflake` **and** `backend-type` ≠ `remote` (with `remote`, the HCP Terraform variable set supplies this) |
+| `SNOWFLAKE_ACCOUNT_NAME`      | Snowflake account name                           | `cloud-provider` = `snowflake` **and** `backend-type` ≠ `remote` (with `remote`, the HCP Terraform variable set supplies this) |
 
 ---
 
@@ -376,7 +376,7 @@ The workflow performs comprehensive input validation before execution:
 - **AWS**: Requires `AWS_REGION` and `AWS_OIDC_ROLE` environment variables
 - **GCP**: Requires `GCP_WIF_PROVIDER` and `GCP_SERVICE_ACCOUNT` environment variables
 - **Azure**: Requires `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` environment variables
-- **Snowflake**: Always requires `SNOWFLAKE_ORGANIZATION_NAME` and `SNOWFLAKE_ACCOUNT_NAME` environment variables. `snowflake-user`, `snowflake-role`, and `snowflake-private-key` are required **only when `backend-type` is not `remote`** — when `backend-type: remote`, these are delegated to the HCP Terraform variable set and any caller-supplied values are only forwarded if non-empty (empty values will not override the variable set)
+- **Snowflake**: When `backend-type` is not `remote`, requires all of `SNOWFLAKE_ORGANIZATION_NAME`, `SNOWFLAKE_ACCOUNT_NAME` environment variables, `snowflake-user` / `snowflake-role` inputs, and `snowflake-private-key` secret. When `backend-type: remote`, all Snowflake credentials are delegated to the HCP Terraform variable set; the workflow only forwards values that are non-empty (empty values will not override the variable set), so GH variables and inputs may be omitted entirely
 - **Databricks**: Requires `databricks-host` and `databricks-token` secrets
 - **Platform**: Validates inputs only for detected provider directories
 


### PR DESCRIPTION
This pull request updates the workflow and documentation to improve support for using HCP Terraform Cloud ("remote" backend) with Snowflake, clarifying how credentials are handled and ensuring robust input validation and sanitization. The workflow now delegates credential management to HCP variable sets when appropriate, and the documentation has been revised to reflect these changes.

**Workflow logic and validation improvements:**

* The workflow now checks if `backend-type` is `remote` for Snowflake, and if so, delegates credential requirements to the HCP Terraform variable set; otherwise, it enforces that all Snowflake credentials are supplied. Error messages and validation logic have been updated accordingly. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR207-R214) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL255-R262)
* Added a step to sanitize and export Snowflake-related Terraform variables, removing CR/LF and trailing whitespace to prevent URL formatting issues in Snowflake account names.

**Credential handling and environment preparation:**

* The step exporting the Snowflake private key to `GITHUB_ENV` has been refactored for clarity and security, and now uses a temporary file and delimiter for multi-line secrets.

**Documentation updates:**

* Updated the documentation to clarify when Snowflake credentials are required, emphasizing that with `backend-type: remote`, credentials are delegated to HCP and should be omitted from the workflow caller to avoid overriding the variable set. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R53) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R62) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R80) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R253-R278) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L353-R379)
* Added an example for using Snowflake with HCP Terraform Cloud backend, illustrating the minimal required inputs and secrets.

These changes make the workflow more robust and user-friendly, especially when integrating with HCP Terraform Cloud for Snowflake deployments.